### PR TITLE
perf: fused GEMM + zero-copy decode + kernel optimizations (192→259 t…

### DIFF
--- a/crates/infer-core/src/model/llama3.rs
+++ b/crates/infer-core/src/model/llama3.rs
@@ -34,9 +34,7 @@ pub struct LlamaLayers {
     // ---- Transformer Blocks (按类型组织) ----
     pub rmsnorm_attn_layers: Vec<RMSNorm>,
     pub rmsnorm_ffn_layers: Vec<RMSNorm>,
-    pub wq_layers: Vec<Matmul>,
-    pub wk_layers: Vec<Matmul>,
-    pub wv_layers: Vec<Matmul>,
+    pub wqkv_layers: Vec<Matmul>,  // fused QKV
     pub wo_layers: Vec<Matmul>,
     pub mha_layers: Vec<FlashAttnGQA>,
     pub rope_layers: Vec<RoPEOp>,
@@ -44,9 +42,8 @@ pub struct LlamaLayers {
     pub scatter_layer: Scatter,
     
     // FFN layers
-    pub w1_layers: Vec<Matmul>, // gate_proj
+    pub w_gate_up_layers: Vec<Matmul>, // fused gate+up
     pub w2_layers: Vec<Matmul>, // down_proj
-    pub w3_layers: Vec<Matmul>, // up_proj
     pub swiglu_layers: Vec<SwiGLU>,
 }
 
@@ -67,15 +64,12 @@ impl LlamaLayers {
         self.rmsnorm_ffn_layers.iter_mut().try_for_each(|layer| layer.to_cuda(device_id))?;
 
         // --- Attention Matmul Layers ---
-        self.wq_layers.iter_mut().try_for_each(|layer| layer.to_cuda(device_id))?;
-        self.wk_layers.iter_mut().try_for_each(|layer| layer.to_cuda(device_id))?;
-        self.wv_layers.iter_mut().try_for_each(|layer| layer.to_cuda(device_id))?;
+        self.wqkv_layers.iter_mut().try_for_each(|layer| layer.to_cuda(device_id))?;
         self.wo_layers.iter_mut().try_for_each(|layer| layer.to_cuda(device_id))?;
 
         // --- FFN Matmul Layers ---
-        self.w1_layers.iter_mut().try_for_each(|layer| layer.to_cuda(device_id))?;
+        self.w_gate_up_layers.iter_mut().try_for_each(|layer| layer.to_cuda(device_id))?;
         self.w2_layers.iter_mut().try_for_each(|layer| layer.to_cuda(device_id))?;
-        self.w3_layers.iter_mut().try_for_each(|layer| layer.to_cuda(device_id))?;
 
         // --- Non-parameterized Layers (如果它们有 to_cuda 实现) ---
         // 这种写法等同于您参考代码中的 for 循环，但更符合 Rust 风格
@@ -214,33 +208,24 @@ impl Llama3 {
             cls_layer,
             rmsnorm_attn_layers,
             rmsnorm_ffn_layers,
-            wq_layers,
-            wk_layers,
-            wv_layers,
+            wqkv_layers,
             wo_layers,
-            w1_layers,
+            w_gate_up_layers,
             w2_layers,
-            w3_layers,
         ) = if !is_quant_model {
             // === 非量化路径 (Normal Path) ===
             let layer_num = config.layer_num;
             let mut rmsnorm_attn_layers = Vec::with_capacity(layer_num);
             let mut rmsnorm_ffn_layers = Vec::with_capacity(layer_num);
-            let mut wq_layers = Vec::with_capacity(layer_num);
-            let mut wk_layers = Vec::with_capacity(layer_num);
-            let mut wv_layers = Vec::with_capacity(layer_num);
+            let mut wqkv_layers = Vec::with_capacity(layer_num);
             let mut wo_layers = Vec::with_capacity(layer_num);
-            let mut w1_layers = Vec::with_capacity(layer_num);
+            let mut w_gate_up_layers = Vec::with_capacity(layer_num);
             let mut w2_layers = Vec::with_capacity(layer_num);
-            let mut w3_layers = Vec::with_capacity(layer_num);
-            
+
             for i in 0..layer_num {
-                wq_layers.push(Self::load_matmul(&format!("model.layers.{}.self_attn.q_proj.weight", i), &loader, device_type)?);
-                wk_layers.push(Self::load_matmul(&format!("model.layers.{}.self_attn.k_proj.weight", i), &loader, device_type)?);
-                wv_layers.push(Self::load_matmul(&format!("model.layers.{}.self_attn.v_proj.weight", i), &loader, device_type)?);
+                wqkv_layers.push(Self::load_fused_qkv(i, &loader, device_type, config.q_dim, config.kv_dim, config.dim)?);
                 wo_layers.push(Self::load_matmul(&format!("model.layers.{}.self_attn.o_proj.weight", i), &loader, device_type)?);
-                w1_layers.push(Self::load_matmul(&format!("model.layers.{}.mlp.gate_proj.weight", i), &loader, device_type)?);
-                w3_layers.push(Self::load_matmul(&format!("model.layers.{}.mlp.up_proj.weight", i), &loader, device_type)?);
+                w_gate_up_layers.push(Self::load_fused_gate_up(i, &loader, device_type, config.intermediate_size, config.dim)?);
                 w2_layers.push(Self::load_matmul(&format!("model.layers.{}.mlp.down_proj.weight", i), &loader, device_type)?);
                 rmsnorm_attn_layers.push(Self::load_rmsnorm(&format!("model.layers.{}.input_layernorm.weight", i), &loader, device_type)?);
                 rmsnorm_ffn_layers.push(Self::load_rmsnorm(&format!("model.layers.{}.post_attention_layernorm.weight", i), &loader, device_type)?);
@@ -264,13 +249,10 @@ impl Llama3 {
                 cls_layer,
                 rmsnorm_attn_layers,
                 rmsnorm_ffn_layers,
-                wq_layers,
-                wk_layers,
-                wv_layers,
+                wqkv_layers,
                 wo_layers,
-                w1_layers,
+                w_gate_up_layers,
                 w2_layers,
-                w3_layers,
             )
         } else {
             // === 量化路径 (Quantized Path) ===
@@ -298,12 +280,11 @@ impl Llama3 {
              return Err(InternalError("Incorrect number of RMSNorm layers created.".to_string()).into());
         }
 
-        if wq_layers.len() != layer_num || wk_layers.len() != layer_num || 
-           wv_layers.len() != layer_num || wo_layers.len() != layer_num {
+        if wqkv_layers.len() != layer_num || wo_layers.len() != layer_num {
             return Err(InternalError("Incorrect number of attention Matmul layers created.".to_string()).into());
         }
-        
-        if w1_layers.len() != layer_num || w2_layers.len() != layer_num || w3_layers.len() != layer_num {
+
+        if w_gate_up_layers.len() != layer_num || w2_layers.len() != layer_num {
             return Err(InternalError("Incorrect number of FFN Matmul layers created.".to_string()).into());
         }
         // 对于无参数算子，`.collect()` 保证了长度，但检查一下也无妨。
@@ -319,17 +300,14 @@ impl Llama3 {
             cls_layer,
             rmsnorm_attn_layers,
             rmsnorm_ffn_layers,
-            wq_layers,
-            wk_layers,
-            wv_layers,
+            wqkv_layers,
             wo_layers,
             mha_layers,
             rope_layers,
             add_layers,
             scatter_layer: Scatter::new(),
-            w1_layers,
+            w_gate_up_layers,
             w2_layers,
-            w3_layers,
             swiglu_layers,
         };
         
@@ -502,6 +480,16 @@ impl Llama3 {
             BufferType::IntermediateBuffer1,
             Tensor::new(&[max_seq_len, config.dim], float_dtype, *device)?,
         );
+
+        // Fused GEMM output buffers
+        buffers.insert(
+            BufferType::QkvOutput,
+            Tensor::new(&[max_seq_len, config.q_dim + 2 * config.kv_dim], float_dtype, *device)?,
+        );
+        buffers.insert(
+            BufferType::GateUpOutput,
+            Tensor::new(&[max_seq_len, 2 * config.intermediate_size], float_dtype, *device)?,
+        );
         // ==========================================================
         
         // 10. 模型的最终 logits 输出 (用于单 token)
@@ -529,7 +517,93 @@ impl Llama3 {
         Ok(Matmul::from(weight_on_device, None))
     }
 
-    // ======================= 已修改的函数 =======================
+    /// Load q_proj, k_proj, v_proj weights and concat into fused [q_dim + 2*kv_dim, dim]
+    fn load_fused_qkv(
+        layer_idx: usize,
+        loader: &ModelLoader,
+        device: DeviceType,
+        q_dim: usize,
+        kv_dim: usize,
+        dim: usize,
+    ) -> Result<Matmul> {
+        let wq_view = loader.get_tensor(&format!("model.layers.{}.self_attn.q_proj.weight", layer_idx))?;
+        let wk_view = loader.get_tensor(&format!("model.layers.{}.self_attn.k_proj.weight", layer_idx))?;
+        let wv_view = loader.get_tensor(&format!("model.layers.{}.self_attn.v_proj.weight", layer_idx))?;
+
+        let wq = Tensor::from_view_on_cpu(&wq_view)?;
+        let wk = Tensor::from_view_on_cpu(&wk_view)?;
+        let wv = Tensor::from_view_on_cpu(&wv_view)?;
+
+        // Determine dtype (BF16 for GPU, F32 for CPU)
+        let dtype = wq.dtype();
+        let fused_rows = q_dim + 2 * kv_dim;
+        let mut fused = Tensor::new(&[fused_rows, dim], dtype, DeviceType::Cpu)?;
+
+        // Copy weight data: [Wq; Wk; Wv] along rows
+        let elem_size = dtype.size_in_bytes();
+        let wq_bytes = q_dim * dim * elem_size;
+        let wk_bytes = kv_dim * dim * elem_size;
+        let wv_bytes = kv_dim * dim * elem_size;
+
+        let fused_ptr = fused.buffer_mut().as_mut_ptr();
+        let wq_ptr = wq.buffer().as_ptr();
+        let wk_ptr = wk.buffer().as_ptr();
+        let wv_ptr = wv.buffer().as_ptr();
+        // SAFETY: All pointers are valid and non-overlapping. Sizes are checked above.
+        unsafe {
+            std::ptr::copy_nonoverlapping(wq_ptr, fused_ptr, wq_bytes);
+            std::ptr::copy_nonoverlapping(wk_ptr, fused_ptr.add(wq_bytes), wk_bytes);
+            std::ptr::copy_nonoverlapping(wv_ptr, fused_ptr.add(wq_bytes + wk_bytes), wv_bytes);
+        }
+
+        let fused_converted = if device.is_cpu() && dtype != DataType::F32 {
+            fused.to_dtype(DataType::F32)?
+        } else {
+            fused
+        };
+        let fused_on_device = fused_converted.to_device(device)?;
+        Ok(Matmul::from(fused_on_device, None))
+    }
+
+    /// Load gate_proj, up_proj weights and concat into fused [2*intermediate_size, dim]
+    fn load_fused_gate_up(
+        layer_idx: usize,
+        loader: &ModelLoader,
+        device: DeviceType,
+        intermediate_size: usize,
+        dim: usize,
+    ) -> Result<Matmul> {
+        let w1_view = loader.get_tensor(&format!("model.layers.{}.mlp.gate_proj.weight", layer_idx))?;
+        let w3_view = loader.get_tensor(&format!("model.layers.{}.mlp.up_proj.weight", layer_idx))?;
+
+        let w1 = Tensor::from_view_on_cpu(&w1_view)?;
+        let w3 = Tensor::from_view_on_cpu(&w3_view)?;
+
+        let dtype = w1.dtype();
+        let fused_rows = 2 * intermediate_size;
+        let mut fused = Tensor::new(&[fused_rows, dim], dtype, DeviceType::Cpu)?;
+
+        let elem_size = dtype.size_in_bytes();
+        let w1_bytes = intermediate_size * dim * elem_size;
+        let w3_bytes = intermediate_size * dim * elem_size;
+
+        let fused_ptr = fused.buffer_mut().as_mut_ptr();
+        let w1_ptr = w1.buffer().as_ptr();
+        let w3_ptr = w3.buffer().as_ptr();
+        // SAFETY: All pointers are valid and non-overlapping. Sizes are checked above.
+        unsafe {
+            std::ptr::copy_nonoverlapping(w1_ptr, fused_ptr, w1_bytes);
+            std::ptr::copy_nonoverlapping(w3_ptr, fused_ptr.add(w1_bytes), w3_bytes);
+        }
+
+        let fused_converted = if device.is_cpu() && dtype != DataType::F32 {
+            fused.to_dtype(DataType::F32)?
+        } else {
+            fused
+        };
+        let fused_on_device = fused_converted.to_device(device)?;
+        Ok(Matmul::from(fused_on_device, None))
+    }
     fn load_rmsnorm(name: &str, loader: &ModelLoader, device: DeviceType) -> Result<RMSNorm> {
         let tensor_view = loader.get_tensor(name)?;
         
@@ -680,53 +754,106 @@ impl Llama3 {
         for i in 0..self.config.layer_num {
             let attn_norm_out_buffer = self.workspace.get_mut(&BufferType::RmsOutput).unwrap();
             let mut attn_norm_out = attn_norm_out_buffer.slice(&[0, 0], &[1, self.config.dim])?;
-            self.layers.rmsnorm_attn_layers[i].forward(&mut OpContext::new(&[&x], &mut [&mut attn_norm_out], cuda_config_ref))?;
-            
-            let q_buffer = self.workspace.get_mut(&BufferType::Query).unwrap();
-            let mut q = q_buffer.slice(&[0, 0], &[1, self.config.dim])?;
-            self.layers.wq_layers[i].forward(&mut OpContext::new(&[&attn_norm_out], &mut [&mut q], cuda_config_ref))?;
-            self.layers.wk_layers[i].forward(&mut OpContext::new(&[&attn_norm_out], &mut [&mut self.kcache], cuda_config_ref))?;
-            self.layers.wv_layers[i].forward(&mut OpContext::new(&[&attn_norm_out], &mut [&mut self.vcache], cuda_config_ref))?;
+            // Layer 0: compute attn_norm normally
+            // Layer 1+: attn_norm already computed by previous layer's fused_add_rmsnorm (on CUDA)
+            #[cfg(feature = "cuda")]
+            if i == 0 || !self.device_type.is_cuda() {
+                self.layers.rmsnorm_attn_layers[i].forward(&mut OpContext::new(&[&x], &mut [&mut attn_norm_out], cuda_config_ref))?;
+            }
+            #[cfg(not(feature = "cuda"))]
+            {
+                self.layers.rmsnorm_attn_layers[i].forward(&mut OpContext::new(&[&x], &mut [&mut attn_norm_out], cuda_config_ref))?;
+            }
+
+            // Fused QKV GEMM
+            let qkv_cols = self.config.q_dim + 2 * self.config.kv_dim;
+            let qkv_buffer = self.workspace.get_mut(&BufferType::QkvOutput).unwrap();
+            let mut qkv = qkv_buffer.slice(&[0, 0], &[1, qkv_cols])?;
+            self.layers.wqkv_layers[i].forward(&mut OpContext::new(&[&attn_norm_out], &mut [&mut qkv], cuda_config_ref))?;
+
+            // Zero-copy slice: seq_len=1, contiguous memory
+            let mut q = qkv.slice(&[0, 0], &[1, self.config.q_dim])?;
+            let mut k = qkv.slice(&[0, self.config.q_dim], &[1, self.config.kv_dim])?;
+            let v = qkv.slice(&[0, self.config.q_dim + self.config.kv_dim], &[1, self.config.kv_dim])?;
             let (k_cache_full, v_cache_full) = self.kv_cache.get_mut(i)?;
-            
+
             let sin_cache = self.workspace.get(&BufferType::SinCache).unwrap();
             let cos_cache = self.workspace.get(&BufferType::CosCache).unwrap();
-            
-            self.layers.rope_layers[i].forward(&mut OpContext::new(&[&self.input_pos, sin_cache, cos_cache], &mut [&mut q, &mut self.kcache], cuda_config_ref))?;
-            self.layers.scatter_layer.forward(&mut OpContext::new(&[&self.kcache, &self.input_pos], &mut [k_cache_full], cuda_config_ref))?;
-            self.layers.scatter_layer.forward(&mut OpContext::new(&[&self.vcache, &self.input_pos], &mut [v_cache_full], cuda_config_ref))?;
+
+            self.layers.rope_layers[i].forward(&mut OpContext::new(&[&self.input_pos, sin_cache, cos_cache], &mut [&mut q, &mut k], cuda_config_ref))?;
+            self.layers.scatter_layer.forward(&mut OpContext::new(&[&k, &self.input_pos], &mut [k_cache_full], cuda_config_ref))?;
+            self.layers.scatter_layer.forward(&mut OpContext::new(&[&v, &self.input_pos], &mut [v_cache_full], cuda_config_ref))?;
             let (k_cache_history, v_cache_history) = self.kv_cache.get(i).unwrap();
             let mut attn_out = attn_norm_out; // Reuse buffer
             self.layers.mha_layers[i].forward(&mut OpContext::new(&[&q, k_cache_history, v_cache_history, &self.input_pos], &mut [&mut attn_out], cuda_config_ref))?;
             let mut wo_out = q; // Reuse buffer
             self.layers.wo_layers[i].forward(&mut OpContext::new(&[&attn_out], &mut [&mut wo_out], cuda_config_ref))?;
-            self.layers.add_layers.forward(&mut OpContext::new(&[&wo_out], &mut [&mut x], cuda_config_ref))?;
-            // FFN Block
+            // Fused: x += wo_out; ffn_norm_out = rmsnorm(x, ffn_weight)
             let mut ffn_norm_out = attn_out; // Reuse buffer
-            self.layers.rmsnorm_ffn_layers[i].forward(&mut OpContext::new(&[&x], &mut [&mut ffn_norm_out], cuda_config_ref))?;
-            let w1_buffer = self.workspace.get_mut(&BufferType::W1Output).unwrap();
-            let mut w1_out = w1_buffer.slice(&[0, 0], &[1, self.config.intermediate_size])?;
-            let w3_buffer = self.workspace.get_mut(&BufferType::W3Output).unwrap();
-            let mut w3_out = w3_buffer.slice(&[0, 0], &[1, self.config.intermediate_size])?;
-            self.layers.w1_layers[i].forward(&mut OpContext::new(&[&ffn_norm_out], &mut [&mut w1_out], cuda_config_ref))?;
-            self.layers.w3_layers[i].forward(&mut OpContext::new(&[&ffn_norm_out], &mut [&mut w3_out], cuda_config_ref))?;
+            #[cfg(feature = "cuda")]
+            if self.device_type.is_cuda() {
+                crate::op::kernels::cuda::fused_add_rmsnorm(
+                    &mut ffn_norm_out,
+                    &mut x,
+                    &wo_out,
+                    &self.layers.rmsnorm_ffn_layers[i].weight,
+                    cuda_config_ref,
+                )?;
+            }
+            #[cfg(not(feature = "cuda"))]
+            {
+                self.layers.add_layers.forward(&mut OpContext::new(&[&wo_out], &mut [&mut x], cuda_config_ref))?;
+                self.layers.rmsnorm_ffn_layers[i].forward(&mut OpContext::new(&[&x], &mut [&mut ffn_norm_out], cuda_config_ref))?;
+            }
+
+            // Fused Gate-Up GEMM
+            let inter = self.config.intermediate_size;
+            let gu_buffer = self.workspace.get_mut(&BufferType::GateUpOutput).unwrap();
+            let mut gate_up = gu_buffer.slice(&[0, 0], &[1, 2 * inter])?;
+            self.layers.w_gate_up_layers[i].forward(&mut OpContext::new(&[&ffn_norm_out], &mut [&mut gate_up], cuda_config_ref))?;
+            // Zero-copy slice
+            let mut w1_out = gate_up.slice(&[0, 0], &[1, inter])?;
+            let w3_out = gate_up.slice(&[0, inter], &[1, inter])?;
             self.layers.swiglu_layers[i].forward(&mut OpContext::new(&[&w3_out], &mut [&mut w1_out], cuda_config_ref))?;
 
             let mut w2_out = ffn_norm_out; // Reuse buffer
             self.layers.w2_layers[i].forward(&mut OpContext::new(&[&w1_out], &mut [&mut w2_out], cuda_config_ref))?;
-            self.layers.add_layers.forward(&mut OpContext::new(&[&w2_out], &mut [&mut x], cuda_config_ref))?;
+            // Fused: x += w2_out; next_norm = rmsnorm(x, next_weight)
+            #[cfg(feature = "cuda")]
+            if self.device_type.is_cuda() {
+                if i + 1 < self.config.layer_num {
+                    let next_norm_buffer = self.workspace.get_mut(&BufferType::RmsOutput).unwrap();
+                    let mut next_attn_norm_out = next_norm_buffer.slice(&[0, 0], &[1, self.config.dim])?;
+                    crate::op::kernels::cuda::fused_add_rmsnorm(
+                        &mut next_attn_norm_out, &mut x, &w2_out,
+                        &self.layers.rmsnorm_attn_layers[i + 1].weight, cuda_config_ref,
+                    )?;
+                } else {
+                    let final_norm_buffer = self.workspace.get_mut(&BufferType::RmsOutput).unwrap();
+                    let mut final_norm_out = final_norm_buffer.slice(&[0, 0], &[1, self.config.dim])?;
+                    crate::op::kernels::cuda::fused_add_rmsnorm(
+                        &mut final_norm_out, &mut x, &w2_out,
+                        &self.layers.rmsnorm_final_layer.weight, cuda_config_ref,
+                    )?;
+                }
+            }
+            #[cfg(not(feature = "cuda"))]
+            {
+                self.layers.add_layers.forward(&mut OpContext::new(&[&w2_out], &mut [&mut x], cuda_config_ref))?;
+            }
 
         }
-        // Extract last token's hidden state
-        let last_hidden_state_view = x.slice(&[0, 0], &[1, self.config.dim])?;
-        
-        // Final Norm and classifier
+
+        // For CUDA: final_norm already computed in fused kernel above
+        // For CPU: compute final_norm separately
         let final_norm_out_buffer = self.workspace.get_mut(&BufferType::RmsOutput).unwrap();
         let mut final_norm_out = final_norm_out_buffer.slice(&[0, 0], &[1, self.config.dim])?;
-
-        self.layers.rmsnorm_final_layer.forward(
-            &mut OpContext::new(&[&last_hidden_state_view], &mut [&mut final_norm_out], cuda_config_ref)
-        )?;
+        #[cfg(not(feature = "cuda"))]
+        {
+            self.layers.rmsnorm_final_layer.forward(
+                &mut OpContext::new(&[&x], &mut [&mut final_norm_out], cuda_config_ref)
+            )?;
+        }
 
         let logits = self.workspace.get_mut(&BufferType::ForwardOutput).unwrap();
 
@@ -786,15 +913,34 @@ impl Llama3 {
             self.layers.rmsnorm_attn_layers[i].forward(&mut OpContext::new(&[&x], &mut [&mut attn_norm_out], cuda_config_ref))?;
 
             let q_buffer = self.workspace.get_mut(&BufferType::Query).unwrap();
-            let mut q = q_buffer.slice(&[0, 0], &[total_tokens, self.config.dim])?;
+            let mut q = q_buffer.slice(&[0, 0], &[total_tokens, self.config.q_dim])?;
 
             // For batch processing, we need to handle KV cache for each sequence separately
             // For now, process each user's KV cache sequentially within the batch
             let (mut k, mut v) = self.kv_cache.slice_kv_cache(i, pos as i32, total_tokens, self.config.kv_dim)?;
 
-            self.layers.wq_layers[i].forward(&mut OpContext::new(&[&attn_norm_out], &mut [&mut q], cuda_config_ref))?;
-            self.layers.wk_layers[i].forward(&mut OpContext::new(&[&attn_norm_out], &mut [&mut k], cuda_config_ref))?;
-            self.layers.wv_layers[i].forward(&mut OpContext::new(&[&attn_norm_out], &mut [&mut v], cuda_config_ref))?;
+            // Fused QKV GEMM
+            let qkv_cols = self.config.q_dim + 2 * self.config.kv_dim;
+            let qkv_buffer = self.workspace.get_mut(&BufferType::QkvOutput).unwrap();
+            let mut qkv = qkv_buffer.slice(&[0, 0], &[total_tokens, qkv_cols])?;
+            self.layers.wqkv_layers[i].forward(&mut OpContext::new(&[&attn_norm_out], &mut [&mut qkv], cuda_config_ref))?;
+
+            #[cfg(feature = "cuda")]
+            if self.device_type.is_cuda() {
+                let stream = cuda_config_ref.map_or(std::ptr::null_mut(), |c| c.stream);
+                crate::op::kernels::cuda::split_cols_bf16_tensor(&qkv, &mut q, total_tokens, qkv_cols, 0, self.config.q_dim, stream)?;
+                crate::op::kernels::cuda::split_cols_bf16_tensor(&qkv, &mut k, total_tokens, qkv_cols, self.config.q_dim, self.config.kv_dim, stream)?;
+                crate::op::kernels::cuda::split_cols_bf16_tensor(&qkv, &mut v, total_tokens, qkv_cols, self.config.q_dim + self.config.kv_dim, self.config.kv_dim, stream)?;
+            }
+            #[cfg(not(feature = "cuda"))]
+            {
+                let q_view = qkv.slice(&[0, 0], &[total_tokens, self.config.q_dim])?;
+                q.copy_from(&q_view)?;
+                let k_view = qkv.slice(&[0, self.config.q_dim], &[total_tokens, self.config.kv_dim])?;
+                k.copy_from(&k_view)?;
+                let v_view = qkv.slice(&[0, self.config.q_dim + self.config.kv_dim], &[total_tokens, self.config.kv_dim])?;
+                v.copy_from(&v_view)?;
+            }
 
             let sin_cache = self.workspace.get(&BufferType::SinCache).unwrap();
             let cos_cache = self.workspace.get(&BufferType::CosCache).unwrap();
@@ -817,8 +963,25 @@ impl Llama3 {
             let w3_buffer = self.workspace.get_mut(&BufferType::W3Output).unwrap();
             let mut w3_out = w3_buffer.slice(&[0, 0], &[total_tokens, self.config.intermediate_size])?;
 
-            self.layers.w1_layers[i].forward(&mut OpContext::new(&[&ffn_norm_out], &mut [&mut w1_out], cuda_config_ref))?;
-            self.layers.w3_layers[i].forward(&mut OpContext::new(&[&ffn_norm_out], &mut [&mut w3_out], cuda_config_ref))?;
+            // Fused Gate-Up GEMM
+            let inter = self.config.intermediate_size;
+            let gu_buffer = self.workspace.get_mut(&BufferType::GateUpOutput).unwrap();
+            let mut gate_up = gu_buffer.slice(&[0, 0], &[total_tokens, 2 * inter])?;
+            self.layers.w_gate_up_layers[i].forward(&mut OpContext::new(&[&ffn_norm_out], &mut [&mut gate_up], cuda_config_ref))?;
+
+            #[cfg(feature = "cuda")]
+            if self.device_type.is_cuda() {
+                let stream = cuda_config_ref.map_or(std::ptr::null_mut(), |c| c.stream);
+                crate::op::kernels::cuda::split_cols_bf16_tensor(&gate_up, &mut w1_out, total_tokens, 2 * inter, 0, inter, stream)?;
+                crate::op::kernels::cuda::split_cols_bf16_tensor(&gate_up, &mut w3_out, total_tokens, 2 * inter, inter, inter, stream)?;
+            }
+            #[cfg(not(feature = "cuda"))]
+            {
+                let g_view = gate_up.slice(&[0, 0], &[total_tokens, inter])?;
+                w1_out.copy_from(&g_view)?;
+                let u_view = gate_up.slice(&[0, inter], &[total_tokens, inter])?;
+                w3_out.copy_from(&u_view)?;
+            }
             self.layers.swiglu_layers[i].forward(&mut OpContext::new(&[&w3_out], &mut [&mut w1_out], cuda_config_ref))?;
 
             let mut w2_out = ffn_norm_out; // Reuse buffer
@@ -892,11 +1055,32 @@ impl Llama3 {
             self.layers.rmsnorm_attn_layers[i].forward(&mut OpContext::new(&[&x], &mut [&mut attn_norm_out], cuda_config_ref))?;
             
             let q_buffer = self.workspace.get_mut(&BufferType::Query).unwrap();
-            let mut q = q_buffer.slice(&[0, 0], &[seq_len, self.config.dim])?;
+            let mut q = q_buffer.slice(&[0, 0], &[seq_len, self.config.q_dim])?;
             let (mut k, mut v) = self.kv_cache.slice_kv_cache(i, pos as i32, seq_len, self.config.kv_dim)?;
-            self.layers.wq_layers[i].forward(&mut OpContext::new(&[&attn_norm_out], &mut [&mut q], cuda_config_ref))?;
-            self.layers.wk_layers[i].forward(&mut OpContext::new(&[&attn_norm_out], &mut [&mut k], cuda_config_ref))?;
-            self.layers.wv_layers[i].forward(&mut OpContext::new(&[&attn_norm_out], &mut [&mut v], cuda_config_ref))?;
+
+            // Fused QKV GEMM
+            let qkv_cols = self.config.q_dim + 2 * self.config.kv_dim;
+            let qkv_buffer = self.workspace.get_mut(&BufferType::QkvOutput).unwrap();
+            let mut qkv = qkv_buffer.slice(&[0, 0], &[seq_len, qkv_cols])?;
+            self.layers.wqkv_layers[i].forward(&mut OpContext::new(&[&attn_norm_out], &mut [&mut qkv], cuda_config_ref))?;
+
+            #[cfg(feature = "cuda")]
+            if self.device_type.is_cuda() {
+                let stream = cuda_config_ref.map_or(std::ptr::null_mut(), |c| c.stream);
+                crate::op::kernels::cuda::split_cols_bf16_tensor(&qkv, &mut q, seq_len, qkv_cols, 0, self.config.q_dim, stream)?;
+                crate::op::kernels::cuda::split_cols_bf16_tensor(&qkv, &mut k, seq_len, qkv_cols, self.config.q_dim, self.config.kv_dim, stream)?;
+                crate::op::kernels::cuda::split_cols_bf16_tensor(&qkv, &mut v, seq_len, qkv_cols, self.config.q_dim + self.config.kv_dim, self.config.kv_dim, stream)?;
+            }
+            #[cfg(not(feature = "cuda"))]
+            {
+                // CPU fallback: use copy_from with slices
+                let q_view = qkv.slice(&[0, 0], &[seq_len, self.config.q_dim])?;
+                q.copy_from(&q_view)?;
+                let k_view = qkv.slice(&[0, self.config.q_dim], &[seq_len, self.config.kv_dim])?;
+                k.copy_from(&k_view)?;
+                let v_view = qkv.slice(&[0, self.config.q_dim + self.config.kv_dim], &[seq_len, self.config.kv_dim])?;
+                v.copy_from(&v_view)?;
+            }
             let sin_cache = self.workspace.get(&BufferType::SinCache).unwrap();
             let cos_cache = self.workspace.get(&BufferType::CosCache).unwrap();
             self.layers.rope_layers[i].forward(&mut OpContext::new(&[&self.input_pos, sin_cache, cos_cache], &mut [&mut q, &mut k], cuda_config_ref))?;
@@ -913,8 +1097,26 @@ impl Llama3 {
             let mut w1_out = w1_buffer.slice(&[0, 0], &[seq_len, self.config.intermediate_size])?;
             let w3_buffer = self.workspace.get_mut(&BufferType::W3Output).unwrap();
             let mut w3_out = w3_buffer.slice(&[0, 0], &[seq_len, self.config.intermediate_size])?;
-            self.layers.w1_layers[i].forward(&mut OpContext::new(&[&ffn_norm_out], &mut [&mut w1_out], cuda_config_ref))?;
-            self.layers.w3_layers[i].forward(&mut OpContext::new(&[&ffn_norm_out], &mut [&mut w3_out], cuda_config_ref))?;
+
+            // Fused Gate-Up GEMM
+            let inter = self.config.intermediate_size;
+            let gu_buffer = self.workspace.get_mut(&BufferType::GateUpOutput).unwrap();
+            let mut gate_up = gu_buffer.slice(&[0, 0], &[seq_len, 2 * inter])?;
+            self.layers.w_gate_up_layers[i].forward(&mut OpContext::new(&[&ffn_norm_out], &mut [&mut gate_up], cuda_config_ref))?;
+
+            #[cfg(feature = "cuda")]
+            if self.device_type.is_cuda() {
+                let stream = cuda_config_ref.map_or(std::ptr::null_mut(), |c| c.stream);
+                crate::op::kernels::cuda::split_cols_bf16_tensor(&gate_up, &mut w1_out, seq_len, 2 * inter, 0, inter, stream)?;
+                crate::op::kernels::cuda::split_cols_bf16_tensor(&gate_up, &mut w3_out, seq_len, 2 * inter, inter, inter, stream)?;
+            }
+            #[cfg(not(feature = "cuda"))]
+            {
+                let g_view = gate_up.slice(&[0, 0], &[seq_len, inter])?;
+                w1_out.copy_from(&g_view)?;
+                let u_view = gate_up.slice(&[0, inter], &[seq_len, inter])?;
+                w3_out.copy_from(&u_view)?;
+            }
             self.layers.swiglu_layers[i].forward(&mut OpContext::new(&[&w3_out], &mut [&mut w1_out], cuda_config_ref))?;
 
             let mut w2_out = ffn_norm_out; // Reuse buffer

--- a/crates/infer-core/src/model/mod.rs
+++ b/crates/infer-core/src/model/mod.rs
@@ -250,6 +250,10 @@ pub enum BufferType {
     // Qwen3 QK-norm buffers (per-head reshape)
     QNormBuffer,
     KNormBuffer,
+
+    // Fused GEMM output buffers
+    QkvOutput,     // [max_seq_len, q_dim + 2 * kv_dim]
+    GateUpOutput,  // [max_seq_len, 2 * intermediate_size]
 }
 
 pub type Workspace = HashMap<BufferType, Tensor>;

--- a/crates/infer-core/src/model/qwen3.rs
+++ b/crates/infer-core/src/model/qwen3.rs
@@ -42,9 +42,7 @@ pub struct Qwen3Layers {
     pub qnorm_layers: Option<Vec<RMSNorm>>, // Query normalization
     pub knorm_layers: Option<Vec<RMSNorm>>, // Key normalization
 
-    pub wq_layers: Vec<Matmul>,
-    pub wk_layers: Vec<Matmul>,
-    pub wv_layers: Vec<Matmul>,
+    pub wqkv_layers: Vec<Matmul>,  // fused QKV: [q_dim + 2*kv_dim, dim]
     pub wo_layers: Vec<Matmul>,
     pub mha_layers: Vec<FlashAttnGQA>,
     pub rope_layers: Vec<RoPEOp>,
@@ -53,9 +51,8 @@ pub struct Qwen3Layers {
 
     // FFN layers
     // Qwen3 使用 SwiGLU，但某些配置可能使用标准的 MLP
-    pub w1_layers: Vec<Matmul>, // gate_proj
+    pub w_gate_up_layers: Vec<Matmul>, // fused gate+up: [2*inter, dim]
     pub w2_layers: Vec<Matmul>, // down_proj
-    pub w3_layers: Vec<Matmul>, // up_proj
     pub swiglu_layers: Vec<SwiGLU>,
 }
 
@@ -91,13 +88,7 @@ impl Qwen3Layers {
         }
 
         // --- Attention Matmul Layers ---
-        self.wq_layers
-            .iter_mut()
-            .try_for_each(|layer| layer.to_cuda(device_id))?;
-        self.wk_layers
-            .iter_mut()
-            .try_for_each(|layer| layer.to_cuda(device_id))?;
-        self.wv_layers
+        self.wqkv_layers
             .iter_mut()
             .try_for_each(|layer| layer.to_cuda(device_id))?;
         self.wo_layers
@@ -105,13 +96,10 @@ impl Qwen3Layers {
             .try_for_each(|layer| layer.to_cuda(device_id))?;
 
         // --- FFN Matmul Layers ---
-        self.w1_layers
+        self.w_gate_up_layers
             .iter_mut()
             .try_for_each(|layer| layer.to_cuda(device_id))?;
         self.w2_layers
-            .iter_mut()
-            .try_for_each(|layer| layer.to_cuda(device_id))?;
-        self.w3_layers
             .iter_mut()
             .try_for_each(|layer| layer.to_cuda(device_id))?;
 
@@ -259,13 +247,10 @@ impl Qwen3 {
             rmsnorm_ffn_layers,
             qnorm_layers,
             knorm_layers,
-            wq_layers,
-            wk_layers,
-            wv_layers,
+            wqkv_layers,
             wo_layers,
-            w1_layers,
+            w_gate_up_layers,
             w2_layers,
-            w3_layers,
         ) = if !is_quant_model {
             // === 非量化路径 (Normal Path) ===
             let layer_num = config.layer_num;
@@ -273,34 +258,20 @@ impl Qwen3 {
             let mut rmsnorm_ffn_layers = Vec::with_capacity(layer_num);
             let mut qnorm_layers_opt = Vec::with_capacity(layer_num);
             let mut knorm_layers_opt = Vec::with_capacity(layer_num);
-            let mut wq_layers = Vec::with_capacity(layer_num);
-            let mut wk_layers = Vec::with_capacity(layer_num);
-            let mut wv_layers = Vec::with_capacity(layer_num);
+            let mut wqkv_layers = Vec::with_capacity(layer_num);
             let mut wo_layers = Vec::with_capacity(layer_num);
-            let mut w1_layers = Vec::with_capacity(layer_num);
+            let mut w_gate_up_layers = Vec::with_capacity(layer_num);
             let mut w2_layers = Vec::with_capacity(layer_num);
-            let mut w3_layers = Vec::with_capacity(layer_num);
 
             // 标记是否存在 QK-norm 层
             let has_qnorm = tensor_names.iter().any(|name| name.contains("q_norm"));
             let has_knorm = tensor_names.iter().any(|name| name.contains("k_norm"));
 
             for i in 0..layer_num {
-                // ---- Attention Layers ----
-                wq_layers.push(Self::load_matmul(
-                    &format!("model.layers.{}.self_attn.q_proj.weight", i),
-                    &loader,
-                    device_type,
-                )?);
-                wk_layers.push(Self::load_matmul(
-                    &format!("model.layers.{}.self_attn.k_proj.weight", i),
-                    &loader,
-                    device_type,
-                )?);
-                wv_layers.push(Self::load_matmul(
-                    &format!("model.layers.{}.self_attn.v_proj.weight", i),
-                    &loader,
-                    device_type,
+                // ---- Attention Layers (fused QKV) ----
+                wqkv_layers.push(Self::load_fused_qkv(
+                    i, &loader, device_type,
+                    config.q_dim, config.kv_dim, config.dim,
                 )?);
                 wo_layers.push(Self::load_matmul(
                     &format!("model.layers.{}.self_attn.o_proj.weight", i),
@@ -308,16 +279,10 @@ impl Qwen3 {
                     device_type,
                 )?);
 
-                // ---- FFN Layers ----
-                w1_layers.push(Self::load_matmul(
-                    &format!("model.layers.{}.mlp.gate_proj.weight", i),
-                    &loader,
-                    device_type,
-                )?);
-                w3_layers.push(Self::load_matmul(
-                    &format!("model.layers.{}.mlp.up_proj.weight", i),
-                    &loader,
-                    device_type,
+                // ---- FFN Layers (fused gate+up) ----
+                w_gate_up_layers.push(Self::load_fused_gate_up(
+                    i, &loader, device_type,
+                    config.intermediate_size, config.dim,
                 )?);
                 w2_layers.push(Self::load_matmul(
                     &format!("model.layers.{}.mlp.down_proj.weight", i),
@@ -385,13 +350,10 @@ impl Qwen3 {
                 rmsnorm_ffn_layers,
                 qnorm_layers_result,
                 knorm_layers_result,
-                wq_layers,
-                wk_layers,
-                wv_layers,
+                wqkv_layers,
                 wo_layers,
-                w1_layers,
+                w_gate_up_layers,
                 w2_layers,
-                w3_layers,
             )
         } else {
             // === 量化路径 (Quantized Path) ===
@@ -420,9 +382,7 @@ impl Qwen3 {
             );
         }
 
-        if wq_layers.len() != layer_num
-            || wk_layers.len() != layer_num
-            || wv_layers.len() != layer_num
+        if wqkv_layers.len() != layer_num
             || wo_layers.len() != layer_num
         {
             return Err(InternalError(
@@ -431,9 +391,8 @@ impl Qwen3 {
             .into());
         }
 
-        if w1_layers.len() != layer_num
+        if w_gate_up_layers.len() != layer_num
             || w2_layers.len() != layer_num
-            || w3_layers.len() != layer_num
         {
             return Err(InternalError(
                 "Incorrect number of FFN Matmul layers created.".to_string(),
@@ -478,17 +437,14 @@ impl Qwen3 {
             rmsnorm_ffn_layers,
             qnorm_layers,
             knorm_layers,
-            wq_layers,
-            wk_layers,
-            wv_layers,
+            wqkv_layers,
             wo_layers,
             mha_layers,
             rope_layers,
             add_layers,
             scatter_layer: Scatter::new(),
-            w1_layers,
+            w_gate_up_layers,
             w2_layers,
-            w3_layers,
             swiglu_layers,
         };
 
@@ -694,6 +650,24 @@ impl Qwen3 {
         let forward_output = Tensor::new(&[config.vocab_size], float_dtype, *device)?;
         buffers.insert(BufferType::ForwardOutput, forward_output);
 
+        // 11. Fused GEMM output buffers
+        buffers.insert(
+            BufferType::QkvOutput,
+            Tensor::new(
+                &[max_seq_len, config.q_dim + 2 * config.kv_dim],
+                float_dtype,
+                *device,
+            )?,
+        );
+        buffers.insert(
+            BufferType::GateUpOutput,
+            Tensor::new(
+                &[max_seq_len, 2 * config.intermediate_size],
+                float_dtype,
+                *device,
+            )?,
+        );
+
         Ok(buffers)
     }
 
@@ -741,6 +715,92 @@ impl Qwen3 {
         let weight_on_device = weight_converted.to_device(device)?;
 
         Ok(Embedding::from(weight_on_device))
+    }
+
+    /// Load q_proj, k_proj, v_proj weights and concat into fused [q_dim+2*kv_dim, dim]
+    fn load_fused_qkv(
+        layer_idx: usize,
+        loader: &ModelLoader,
+        device: DeviceType,
+        q_dim: usize,
+        kv_dim: usize,
+        dim: usize,
+    ) -> Result<Matmul> {
+        let wq_view = loader.get_tensor(&format!("model.layers.{}.self_attn.q_proj.weight", layer_idx))?;
+        let wk_view = loader.get_tensor(&format!("model.layers.{}.self_attn.k_proj.weight", layer_idx))?;
+        let wv_view = loader.get_tensor(&format!("model.layers.{}.self_attn.v_proj.weight", layer_idx))?;
+
+        let wq = Tensor::from_view_on_cpu(&wq_view)?;
+        let wk = Tensor::from_view_on_cpu(&wk_view)?;
+        let wv = Tensor::from_view_on_cpu(&wv_view)?;
+
+        // Determine dtype (BF16 for GPU, F32 for CPU)
+        let dtype = wq.dtype();
+        let fused_rows = q_dim + 2 * kv_dim;
+        let mut fused = Tensor::new(&[fused_rows, dim], dtype, DeviceType::Cpu)?;
+
+        // Copy weight data: [Wq; Wk; Wv] along rows
+        let elem_size = dtype.size_in_bytes();
+        let wq_bytes = q_dim * dim * elem_size;
+        let wk_bytes = kv_dim * dim * elem_size;
+        let wv_bytes = kv_dim * dim * elem_size;
+
+        let fused_ptr = fused.buffer_mut().as_mut_ptr();
+        let wq_ptr = wq.buffer().as_ptr();
+        let wk_ptr = wk.buffer().as_ptr();
+        let wv_ptr = wv.buffer().as_ptr();
+        unsafe {
+            std::ptr::copy_nonoverlapping(wq_ptr, fused_ptr, wq_bytes);
+            std::ptr::copy_nonoverlapping(wk_ptr, fused_ptr.add(wq_bytes), wk_bytes);
+            std::ptr::copy_nonoverlapping(wv_ptr, fused_ptr.add(wq_bytes + wk_bytes), wv_bytes);
+        }
+
+        let fused_converted = if device.is_cpu() && dtype != DataType::F32 {
+            fused.to_dtype(DataType::F32)?
+        } else {
+            fused
+        };
+        let fused_on_device = fused_converted.to_device(device)?;
+        Ok(Matmul::from(fused_on_device, None))
+    }
+
+    /// Load gate_proj, up_proj weights and concat into fused [2*intermediate_size, dim]
+    fn load_fused_gate_up(
+        layer_idx: usize,
+        loader: &ModelLoader,
+        device: DeviceType,
+        intermediate_size: usize,
+        dim: usize,
+    ) -> Result<Matmul> {
+        let w1_view = loader.get_tensor(&format!("model.layers.{}.mlp.gate_proj.weight", layer_idx))?;
+        let w3_view = loader.get_tensor(&format!("model.layers.{}.mlp.up_proj.weight", layer_idx))?;
+
+        let w1 = Tensor::from_view_on_cpu(&w1_view)?;
+        let w3 = Tensor::from_view_on_cpu(&w3_view)?;
+
+        let dtype = w1.dtype();
+        let fused_rows = 2 * intermediate_size;
+        let mut fused = Tensor::new(&[fused_rows, dim], dtype, DeviceType::Cpu)?;
+
+        let elem_size = dtype.size_in_bytes();
+        let w1_bytes = intermediate_size * dim * elem_size;
+        let w3_bytes = intermediate_size * dim * elem_size;
+
+        let fused_ptr = fused.buffer_mut().as_mut_ptr();
+        let w1_ptr = w1.buffer().as_ptr();
+        let w3_ptr = w3.buffer().as_ptr();
+        unsafe {
+            std::ptr::copy_nonoverlapping(w1_ptr, fused_ptr, w1_bytes);
+            std::ptr::copy_nonoverlapping(w3_ptr, fused_ptr.add(w1_bytes), w3_bytes);
+        }
+
+        let fused_converted = if device.is_cpu() && dtype != DataType::F32 {
+            fused.to_dtype(DataType::F32)?
+        } else {
+            fused
+        };
+        let fused_on_device = fused_converted.to_device(device)?;
+        Ok(Matmul::from(fused_on_device, None))
     }
 
     pub fn generate(
@@ -873,29 +933,39 @@ impl Qwen3 {
         for i in 0..self.config.layer_num {
             let attn_norm_out_buffer = self.workspace.get_mut(&BufferType::RmsOutput).unwrap();
             let mut attn_norm_out = attn_norm_out_buffer.slice(&[0, 0], &[1, self.config.dim])?;
-            self.layers.rmsnorm_attn_layers[i].forward(&mut OpContext::new(
-                &[&x],
-                &mut [&mut attn_norm_out],
+            // Layer 0: compute attn_norm normally
+            // Layer 1+: attn_norm already computed by previous layer's fused_add_rmsnorm (on CUDA)
+            #[cfg(feature = "cuda")]
+            if i == 0 || !self.device_type.is_cuda() {
+                self.layers.rmsnorm_attn_layers[i].forward(&mut OpContext::new(
+                    &[&x],
+                    &mut [&mut attn_norm_out],
+                    cuda_config_ref,
+                ))?;
+            }
+            #[cfg(not(feature = "cuda"))]
+            {
+                self.layers.rmsnorm_attn_layers[i].forward(&mut OpContext::new(
+                    &[&x],
+                    &mut [&mut attn_norm_out],
+                    cuda_config_ref,
+                ))?;
+            }
+
+            // ---- Fused QKV GEMM (1 GEMM instead of 3) ----
+            let qkv_cols = self.config.q_dim + 2 * self.config.kv_dim;
+            let qkv_buffer = self.workspace.get_mut(&BufferType::QkvOutput).unwrap();
+            let mut qkv = qkv_buffer.slice(&[0, 0], &[1, qkv_cols])?;
+            self.layers.wqkv_layers[i].forward(&mut OpContext::new(
+                &[&attn_norm_out],
+                &mut [&mut qkv],
                 cuda_config_ref,
             ))?;
 
-            let q_buffer = self.workspace.get_mut(&BufferType::Query).unwrap();
-            let mut q = q_buffer.slice(&[0, 0], &[1, self.config.q_dim])?;
-            self.layers.wq_layers[i].forward(&mut OpContext::new(
-                &[&attn_norm_out],
-                &mut [&mut q],
-                cuda_config_ref,
-            ))?;
-            self.layers.wk_layers[i].forward(&mut OpContext::new(
-                &[&attn_norm_out],
-                &mut [&mut self.kcache],
-                cuda_config_ref,
-            ))?;
-            self.layers.wv_layers[i].forward(&mut OpContext::new(
-                &[&attn_norm_out],
-                &mut [&mut self.vcache],
-                cuda_config_ref,
-            ))?;
+            // Zero-copy slice: seq_len=1, contiguous memory, no kernel launch needed
+            let mut q = qkv.slice(&[0, 0], &[1, self.config.q_dim])?;
+            let mut k_view = qkv.slice(&[0, self.config.q_dim], &[1, self.config.kv_dim])?;
+            let v_view = qkv.slice(&[0, self.config.q_dim + self.config.kv_dim], &[1, self.config.kv_dim])?;
 
             // ---- Qwen3 特定：Per-head QK-norm ----
             let mut q = if let Some(ref qnorm_layers) = self.layers.qnorm_layers {
@@ -913,7 +983,7 @@ impl Qwen3 {
             };
 
             let mut k_active = if let Some(ref knorm_layers) = self.layers.knorm_layers {
-                let k_reshaped = self.kcache.reshape(&[self.config.kv_head_num, self.config.head_size])?;
+                let k_reshaped = k_view.reshape(&[self.config.kv_head_num, self.config.head_size])?;
                 let knorm_buffer = self.workspace.get_mut(&BufferType::KNormBuffer).unwrap();
                 let mut knorm_out = knorm_buffer.slice(&[0, 0], &[self.config.kv_head_num, self.config.head_size])?;
                 knorm_layers[i].forward(&mut OpContext::new(
@@ -923,7 +993,7 @@ impl Qwen3 {
                 ))?;
                 knorm_out.reshape(&[1, self.config.kv_dim])?
             } else {
-                self.kcache.reshape(&[1, self.config.kv_dim])?
+                k_view.reshape(&[1, self.config.kv_dim])?
             };
 
             let (k_cache_full, v_cache_full) = self.kv_cache.get_mut(i)?;
@@ -942,7 +1012,7 @@ impl Qwen3 {
                 cuda_config_ref,
             ))?;
             self.layers.scatter_layer.forward(&mut OpContext::new(
-                &[&self.vcache, &self.input_pos],
+                &[&v_view, &self.input_pos],
                 &mut [v_cache_full],
                 cuda_config_ref,
             ))?;
@@ -962,33 +1032,45 @@ impl Qwen3 {
                 &mut [&mut wo_out],
                 cuda_config_ref,
             ))?;
-            self.layers.add_layers.forward(&mut OpContext::new(
-                &[&wo_out],
-                &mut [&mut x],
-                cuda_config_ref,
-            ))?;
-            // FFN Block - 用 RmsOutput 缓冲区，它是 [1, dim]
+            // Fused: x += wo_out; ffn_norm_out = rmsnorm(x, ffn_weight)
             let ffn_norm_buffer = self.workspace.get_mut(&BufferType::RmsOutput).unwrap();
             let mut ffn_norm_out = ffn_norm_buffer.slice(&[0, 0], &[1, self.config.dim])?;
-            self.layers.rmsnorm_ffn_layers[i].forward(&mut OpContext::new(
-                &[&x],
-                &mut [&mut ffn_norm_out],
-                cuda_config_ref,
-            ))?;
-            let w1_buffer = self.workspace.get_mut(&BufferType::W1Output).unwrap();
-            let mut w1_out = w1_buffer.slice(&[0, 0], &[1, self.config.intermediate_size])?;
-            let w3_buffer = self.workspace.get_mut(&BufferType::W3Output).unwrap();
-            let mut w3_out = w3_buffer.slice(&[0, 0], &[1, self.config.intermediate_size])?;
-            self.layers.w1_layers[i].forward(&mut OpContext::new(
+            #[cfg(feature = "cuda")]
+            if self.device_type.is_cuda() {
+                crate::op::kernels::cuda::fused_add_rmsnorm(
+                    &mut ffn_norm_out,
+                    &mut x,
+                    &wo_out,
+                    &self.layers.rmsnorm_ffn_layers[i].weight,
+                    cuda_config_ref,
+                )?;
+            }
+            #[cfg(not(feature = "cuda"))]
+            {
+                self.layers.add_layers.forward(&mut OpContext::new(
+                    &[&wo_out],
+                    &mut [&mut x],
+                    cuda_config_ref,
+                ))?;
+                self.layers.rmsnorm_ffn_layers[i].forward(&mut OpContext::new(
+                    &[&x],
+                    &mut [&mut ffn_norm_out],
+                    cuda_config_ref,
+                ))?;
+            }
+            // ---- Fused Gate-Up GEMM (1 GEMM instead of 2) ----
+            let inter = self.config.intermediate_size;
+            let gu_buffer = self.workspace.get_mut(&BufferType::GateUpOutput).unwrap();
+            let mut gate_up = gu_buffer.slice(&[0, 0], &[1, 2 * inter])?;
+            self.layers.w_gate_up_layers[i].forward(&mut OpContext::new(
                 &[&ffn_norm_out],
-                &mut [&mut w1_out],
+                &mut [&mut gate_up],
                 cuda_config_ref,
             ))?;
-            self.layers.w3_layers[i].forward(&mut OpContext::new(
-                &[&ffn_norm_out],
-                &mut [&mut w3_out],
-                cuda_config_ref,
-            ))?;
+
+            // Zero-copy slice: gate and up are contiguous in gate_up buffer
+            let mut w1_out = gate_up.slice(&[0, 0], &[1, inter])?;
+            let w3_out = gate_up.slice(&[0, inter], &[1, inter])?;
             self.layers.swiglu_layers[i].forward(&mut OpContext::new(
                 &[&w3_out],
                 &mut [&mut w1_out],
@@ -1001,26 +1083,59 @@ impl Qwen3 {
                 &mut [&mut w2_out],
                 cuda_config_ref,
             ))?;
-            self.layers.add_layers.forward(&mut OpContext::new(
-                &[&w2_out],
-                &mut [&mut x],
-                cuda_config_ref,
-            ))?;
+            // Fused: x += w2_out; next_norm_out = rmsnorm(x, next_norm_weight)
+            // For layers 0..N-2: fuse with attn_norm[i+1]
+            // For last layer: fuse with final_norm
+            #[cfg(feature = "cuda")]
+            if self.device_type.is_cuda() {
+                if i + 1 < self.config.layer_num {
+                    // Not last layer: fuse add + next attn_norm
+                    let next_norm_buffer = self.workspace.get_mut(&BufferType::RmsOutput).unwrap();
+                    let mut next_attn_norm_out = next_norm_buffer.slice(&[0, 0], &[1, self.config.dim])?;
+                    crate::op::kernels::cuda::fused_add_rmsnorm(
+                        &mut next_attn_norm_out,
+                        &mut x,
+                        &w2_out,
+                        &self.layers.rmsnorm_attn_layers[i + 1].weight,
+                        cuda_config_ref,
+                    )?;
+                } else {
+                    // Last layer: fuse add + final_norm
+                    let final_norm_buffer = self.workspace.get_mut(&BufferType::RmsOutput).unwrap();
+                    let mut final_norm_out = final_norm_buffer.slice(&[0, 0], &[1, self.config.dim])?;
+                    crate::op::kernels::cuda::fused_add_rmsnorm(
+                        &mut final_norm_out,
+                        &mut x,
+                        &w2_out,
+                        &self.layers.rmsnorm_final_layer.weight,
+                        cuda_config_ref,
+                    )?;
+                }
+            }
+            #[cfg(not(feature = "cuda"))]
+            {
+                self.layers.add_layers.forward(&mut OpContext::new(
+                    &[&w2_out],
+                    &mut [&mut x],
+                    cuda_config_ref,
+                ))?;
+            }
         }
-        // Extract last token's hidden state
-        let last_hidden_state_view = x.slice(&[0, 0], &[1, self.config.dim])?;
 
-        // Final Norm and classifier
+        // For CUDA: final_norm already computed in fused kernel above
+        // For CPU: compute final_norm separately
         let final_norm_out_buffer = self.workspace.get_mut(&BufferType::RmsOutput).unwrap();
         let mut final_norm_out = final_norm_out_buffer.slice(&[0, 0], &[1, self.config.dim])?;
-
-        self.layers
-            .rmsnorm_final_layer
-            .forward(&mut OpContext::new(
-                &[&last_hidden_state_view],
-                &mut [&mut final_norm_out],
-                cuda_config_ref,
-            ))?;
+        #[cfg(not(feature = "cuda"))]
+        {
+            self.layers
+                .rmsnorm_final_layer
+                .forward(&mut OpContext::new(
+                    &[&x],
+                    &mut [&mut final_norm_out],
+                    cuda_config_ref,
+                ))?;
+        }
 
         let logits = self.workspace.get_mut(&BufferType::ForwardOutput).unwrap();
 
@@ -1091,26 +1206,60 @@ impl Qwen3 {
                 cuda_config_ref,
             ))?;
 
+            // ---- Fused QKV GEMM (prefill) ----
+            let qkv_cols = self.config.q_dim + 2 * self.config.kv_dim;
+            let qkv_buffer = self.workspace.get_mut(&BufferType::QkvOutput).unwrap();
+            let mut qkv = qkv_buffer.slice(&[0, 0], &[seq_len, qkv_cols])?;
+            self.layers.wqkv_layers[i].forward(&mut OpContext::new(
+                &[&attn_norm_out],
+                &mut [&mut qkv],
+                cuda_config_ref,
+            ))?;
+
+            // Split fused output into q, k, v using split_cols kernel (prefill: seq_len>1, non-contiguous cols)
             let q_buffer = self.workspace.get_mut(&BufferType::Query).unwrap();
             let mut q = q_buffer.slice(&[0, 0], &[seq_len, self.config.q_dim])?;
             let (mut k, mut v) =
                 self.kv_cache
                     .slice_kv_cache(i, pos as i32, seq_len, self.config.kv_dim)?;
-            self.layers.wq_layers[i].forward(&mut OpContext::new(
-                &[&attn_norm_out],
-                &mut [&mut q],
-                cuda_config_ref,
-            ))?;
-            self.layers.wk_layers[i].forward(&mut OpContext::new(
-                &[&attn_norm_out],
-                &mut [&mut k],
-                cuda_config_ref,
-            ))?;
-            self.layers.wv_layers[i].forward(&mut OpContext::new(
-                &[&attn_norm_out],
-                &mut [&mut v],
-                cuda_config_ref,
-            ))?;
+
+            #[cfg(feature = "cuda")]
+            if self.device_type.is_cuda() {
+                let stream = cuda_config_ref.map_or(std::ptr::null_mut(), |c| c.stream);
+                crate::op::kernels::cuda::split_cols_bf16_tensor(
+                    &qkv, &mut q, seq_len, qkv_cols, 0, self.config.q_dim, stream)?;
+                crate::op::kernels::cuda::split_cols_bf16_tensor(
+                    &qkv, &mut k, seq_len, qkv_cols, self.config.q_dim, self.config.kv_dim, stream)?;
+                crate::op::kernels::cuda::split_cols_bf16_tensor(
+                    &qkv, &mut v, seq_len, qkv_cols, self.config.q_dim + self.config.kv_dim, self.config.kv_dim, stream)?;
+            }
+            #[cfg(not(feature = "cuda"))]
+            {
+                // CPU fallback: row-by-row copy
+                // For CPU, we can just do the 3 separate GEMMs would be simpler,
+                // but for consistency we split from the fused output
+                let elem_size = qkv.dtype().size_in_bytes();
+                let qkv_ptr = qkv.buffer().as_ptr();
+                let q_ptr = q.buffer_mut().as_mut_ptr();
+                let k_ptr = k.buffer_mut().as_mut_ptr();
+                let v_ptr = v.buffer_mut().as_mut_ptr();
+                for r in 0..seq_len {
+                    unsafe {
+                        std::ptr::copy_nonoverlapping(
+                            qkv_ptr.add(r * qkv_cols * elem_size),
+                            q_ptr.add(r * self.config.q_dim * elem_size),
+                            self.config.q_dim * elem_size);
+                        std::ptr::copy_nonoverlapping(
+                            qkv_ptr.add((r * qkv_cols + self.config.q_dim) * elem_size),
+                            k_ptr.add(r * self.config.kv_dim * elem_size),
+                            self.config.kv_dim * elem_size);
+                        std::ptr::copy_nonoverlapping(
+                            qkv_ptr.add((r * qkv_cols + self.config.q_dim + self.config.kv_dim) * elem_size),
+                            v_ptr.add(r * self.config.kv_dim * elem_size),
+                            self.config.kv_dim * elem_size);
+                    }
+                }
+            }
 
             // ---- Qwen3 Per-head QK-norm ----
             if let Some(ref qnorm_layers) = self.layers.qnorm_layers {
@@ -1175,20 +1324,48 @@ impl Qwen3 {
                 &mut [&mut ffn_norm_out],
                 cuda_config_ref,
             ))?;
+            // ---- Fused Gate-Up GEMM (prefill) ----
+            let inter = self.config.intermediate_size;
+            let gu_buffer = self.workspace.get_mut(&BufferType::GateUpOutput).unwrap();
+            let mut gate_up = gu_buffer.slice(&[0, 0], &[seq_len, 2 * inter])?;
+            self.layers.w_gate_up_layers[i].forward(&mut OpContext::new(
+                &[&ffn_norm_out],
+                &mut [&mut gate_up],
+                cuda_config_ref,
+            ))?;
+
             let w1_buffer = self.workspace.get_mut(&BufferType::W1Output).unwrap();
-            let mut w1_out = w1_buffer.slice(&[0, 0], &[seq_len, self.config.intermediate_size])?;
+            let mut w1_out = w1_buffer.slice(&[0, 0], &[seq_len, inter])?;
             let w3_buffer = self.workspace.get_mut(&BufferType::W3Output).unwrap();
-            let mut w3_out = w3_buffer.slice(&[0, 0], &[seq_len, self.config.intermediate_size])?;
-            self.layers.w1_layers[i].forward(&mut OpContext::new(
-                &[&ffn_norm_out],
-                &mut [&mut w1_out],
-                cuda_config_ref,
-            ))?;
-            self.layers.w3_layers[i].forward(&mut OpContext::new(
-                &[&ffn_norm_out],
-                &mut [&mut w3_out],
-                cuda_config_ref,
-            ))?;
+            let mut w3_out = w3_buffer.slice(&[0, 0], &[seq_len, inter])?;
+
+            #[cfg(feature = "cuda")]
+            if self.device_type.is_cuda() {
+                let stream = cuda_config_ref.map_or(std::ptr::null_mut(), |c| c.stream);
+                crate::op::kernels::cuda::split_cols_bf16_tensor(
+                    &gate_up, &mut w1_out, seq_len, 2 * inter, 0, inter, stream)?;
+                crate::op::kernels::cuda::split_cols_bf16_tensor(
+                    &gate_up, &mut w3_out, seq_len, 2 * inter, inter, inter, stream)?;
+            }
+            #[cfg(not(feature = "cuda"))]
+            {
+                let elem_size = gate_up.dtype().size_in_bytes();
+                let gu_ptr = gate_up.buffer().as_ptr();
+                let w1_ptr = w1_out.buffer_mut().as_mut_ptr();
+                let w3_ptr = w3_out.buffer_mut().as_mut_ptr();
+                for r in 0..seq_len {
+                    unsafe {
+                        std::ptr::copy_nonoverlapping(
+                            gu_ptr.add(r * 2 * inter * elem_size),
+                            w1_ptr.add(r * inter * elem_size),
+                            inter * elem_size);
+                        std::ptr::copy_nonoverlapping(
+                            gu_ptr.add((r * 2 * inter + inter) * elem_size),
+                            w3_ptr.add(r * inter * elem_size),
+                            inter * elem_size);
+                    }
+                }
+            }
             self.layers.swiglu_layers[i].forward(&mut OpContext::new(
                 &[&w3_out],
                 &mut [&mut w1_out],
@@ -1509,16 +1686,34 @@ mod tests {
             println!("[CPU] attn_norm first 8: {:?}", &cpu_norm[..8]);
 
             // wq
+            // fused QKV
+            let qkv_cols = m.config.q_dim + 2 * m.config.kv_dim;
+            let mut qkv_out = Tensor::new(&[seq_len, qkv_cols], DataType::F32, DeviceType::Cpu)?;
+            m.layers.wqkv_layers[0].forward(&mut OpContext::new(&[&norm_out], &mut [&mut qkv_out], cpu_cfg))?;
+
+            // split on CPU
             let q_buf = m.workspace.get_mut(&BufferType::Query).unwrap();
             let mut q = q_buf.slice(&[0, 0], &[seq_len, m.config.q_dim])?;
-            m.layers.wq_layers[0].forward(&mut OpContext::new(&[&norm_out], &mut [&mut q], cpu_cfg))?;
+            let (mut k, mut v) = m.kv_cache.slice_kv_cache(0, 0, seq_len, m.config.kv_dim)?;
+            {
+                let elem = qkv_out.dtype().size_in_bytes();
+                let qkv_ptr = qkv_out.buffer().as_ptr();
+                let q_ptr = q.buffer_mut().as_mut_ptr();
+                let k_ptr = k.buffer_mut().as_mut_ptr();
+                let v_ptr = v.buffer_mut().as_mut_ptr();
+                for r in 0..seq_len {
+                    unsafe {
+                        std::ptr::copy_nonoverlapping(
+                            qkv_ptr.add(r * qkv_cols * elem), q_ptr.add(r * m.config.q_dim * elem), m.config.q_dim * elem);
+                        std::ptr::copy_nonoverlapping(
+                            qkv_ptr.add((r * qkv_cols + m.config.q_dim) * elem), k_ptr.add(r * m.config.kv_dim * elem), m.config.kv_dim * elem);
+                        std::ptr::copy_nonoverlapping(
+                            qkv_ptr.add((r * qkv_cols + m.config.q_dim + m.config.kv_dim) * elem), v_ptr.add(r * m.config.kv_dim * elem), m.config.kv_dim * elem);
+                    }
+                }
+            }
             let cpu_q = q.as_f32()?.as_slice()?.to_vec();
             println!("[CPU] wq first 8: {:?}", &cpu_q[..8]);
-
-            // wk, wv
-            let (mut k, mut v) = m.kv_cache.slice_kv_cache(0, 0, seq_len, m.config.kv_dim)?;
-            m.layers.wk_layers[0].forward(&mut OpContext::new(&[&norm_out], &mut [&mut k], cpu_cfg))?;
-            m.layers.wv_layers[0].forward(&mut OpContext::new(&[&norm_out], &mut [&mut v], cpu_cfg))?;
             let cpu_k = k.as_f32()?.as_slice()?.to_vec();
             println!("[CPU] wk first 8: {:?}", &cpu_k[..8]);
 
@@ -1600,27 +1795,34 @@ mod tests {
             };
             println!("[GPU] attn_norm first 8: {:?}", &gpu_norm[..8]);
 
-            // wq
+            // fused QKV (GPU)
+            let qkv_cols = m.config.q_dim + 2 * m.config.kv_dim;
+            let qkv_buf = m.workspace.get_mut(&BufferType::QkvOutput).unwrap();
+            let mut qkv = qkv_buf.slice(&[0, 0], &[seq_len, qkv_cols])?;
+            m.layers.wqkv_layers[0].forward(&mut OpContext::new(&[&norm_out], &mut [&mut qkv], gpu_cfg))?;
+
+            // split with split_cols kernel
             let q_buf = m.workspace.get_mut(&BufferType::Query).unwrap();
             let mut q = q_buf.slice(&[0, 0], &[seq_len, m.config.q_dim])?;
-            m.layers.wq_layers[0].forward(&mut OpContext::new(&[&norm_out], &mut [&mut q], gpu_cfg))?;
+            let (mut k, mut v) = m.kv_cache.slice_kv_cache(0, 0, seq_len, m.config.kv_dim)?;
+            let stream = gpu_cfg.map_or(std::ptr::null_mut(), |c| c.stream);
+            crate::op::kernels::cuda::split_cols_bf16_tensor(
+                &qkv, &mut q, seq_len, qkv_cols, 0, m.config.q_dim, stream)?;
+            crate::op::kernels::cuda::split_cols_bf16_tensor(
+                &qkv, &mut k, seq_len, qkv_cols, m.config.q_dim, m.config.kv_dim, stream)?;
+            crate::op::kernels::cuda::split_cols_bf16_tensor(
+                &qkv, &mut v, seq_len, qkv_cols, m.config.q_dim + m.config.kv_dim, m.config.kv_dim, stream)?;
+
             let gpu_q: Vec<f32> = {
                 let t = q.to_cpu()?;
                 t.as_bf16()?.as_slice()?.iter().map(|v| v.to_f32()).collect()
             };
             println!("[GPU] wq first 8: {:?}", &gpu_q[..8]);
-
-            // wk
-            let (mut k, mut v) = m.kv_cache.slice_kv_cache(0, 0, seq_len, m.config.kv_dim)?;
-            m.layers.wk_layers[0].forward(&mut OpContext::new(&[&norm_out], &mut [&mut k], gpu_cfg))?;
             let gpu_k: Vec<f32> = {
                 let t = k.to_cpu()?;
                 t.as_bf16()?.as_slice()?.iter().map(|v| v.to_f32()).collect()
             };
             println!("[GPU] wk first 8: {:?}", &gpu_k[..8]);
-
-            // wv
-            m.layers.wv_layers[0].forward(&mut OpContext::new(&[&norm_out], &mut [&mut v], gpu_cfg))?;
 
             // qk-norm
             if let Some(ref qnorm) = m.layers.qnorm_layers {

--- a/crates/infer-core/src/op/kernels/cuda/mod.rs
+++ b/crates/infer-core/src/op/kernels/cuda/mod.rs
@@ -1,6 +1,7 @@
 mod rmsnorm;
 
 pub use rmsnorm::rmsnorm;
+pub use rmsnorm::fused_add_rmsnorm;
 
 mod add;
 pub use add::*;
@@ -26,3 +27,6 @@ pub use sampler::*;
 
 mod scatter;
 pub use scatter::*;
+
+mod split_cols;
+pub use split_cols::*;

--- a/crates/infer-core/src/op/kernels/cuda/rmsnorm/mod.rs
+++ b/crates/infer-core/src/op/kernels/cuda/rmsnorm/mod.rs
@@ -22,6 +22,16 @@ unsafe extern "C" {
         eps: f32,
         stream:crate::cuda::ffi::cudaStream_t,
     );
+    fn fused_add_rmsnorm_kernel_cu_bf16(
+        norm_output: *mut half::bf16,
+        residual: *mut half::bf16,
+        input: *const half::bf16,
+        weight: *const half::bf16,
+        rows: i32,
+        dim: i32,
+        eps: f32,
+        stream: crate::cuda::ffi::cudaStream_t,
+    );
 }
 
 /// RMSNorm 的 CUDA 内核包装函数
@@ -92,5 +102,38 @@ pub fn rmsnorm(input: &Tensor, weight: &Tensor, output: &mut Tensor, cuda_config
         }
     }
 
+    Ok(())
+}
+
+/// Fused: residual += input; norm_output = rmsnorm(residual, weight)
+/// BF16 only. Saves one kernel launch vs separate add + rmsnorm.
+pub fn fused_add_rmsnorm(
+    norm_output: &mut Tensor,
+    residual: &mut Tensor,
+    input: &Tensor,
+    weight: &Tensor,
+    cuda_config: Option<&CudaConfig>,
+) -> Result<()> {
+    let dim = weight.shape()[0];
+    let rows = input.num_elements() / dim;
+    let stream = cuda_config.map_or(std::ptr::null_mut(), |config| config.stream);
+
+    let norm_out_ptr = norm_output.as_bf16_mut()?.buffer_mut().as_mut_ptr() as *mut half::bf16;
+    let res_ptr = residual.as_bf16_mut()?.buffer_mut().as_mut_ptr() as *mut half::bf16;
+    let input_ptr = input.as_bf16()?.buffer().as_ptr() as *const half::bf16;
+    let weight_ptr = weight.as_bf16()?.buffer().as_ptr() as *const half::bf16;
+
+    unsafe {
+        fused_add_rmsnorm_kernel_cu_bf16(
+            norm_out_ptr,
+            res_ptr,
+            input_ptr,
+            weight_ptr,
+            rows as i32,
+            dim as i32,
+            1e-6,
+            stream,
+        );
+    }
     Ok(())
 }

--- a/crates/infer-core/src/op/kernels/cuda/rmsnorm/rmsnorm.cu
+++ b/crates/infer-core/src/op/kernels/cuda/rmsnorm/rmsnorm.cu
@@ -124,3 +124,92 @@ void rmsnorm_kernel_cu_dim(float* output, float* input, float* weight, int row, 
     constexpr int threads_num = 128;
     row_rmsnorm_f32_dim<<<row, threads_num, 0, stream>>>(output, input,  weight, row, dim, eps);
 }
+
+// =====================================================
+// Fused RMSNorm + Residual Add (BF16)
+// residual[i] += input[i];  norm_out[i] = rmsnorm(residual[i], weight)
+// Saves one kernel launch by combining add + rmsnorm into a single pass.
+// =====================================================
+__global__ void fused_add_rmsnorm_bf16_kernel(
+    __nv_bfloat16* __restrict__ norm_output,   // [rows, dim] output of rmsnorm
+    __nv_bfloat16* __restrict__ residual,       // [rows, dim] residual (read + write: residual += input)
+    const __nv_bfloat16* __restrict__ input,    // [rows, dim] input to add
+    const __nv_bfloat16* __restrict__ weight,   // [dim] rmsnorm weight
+    int dim,
+    float eps
+) {
+    const int row_offset = blockIdx.x * dim;
+    const int tid = threadIdx.x;
+
+    // Vectorized pointers (8 bf16 = 1 float4)
+    float4* res_f4 = reinterpret_cast<float4*>(residual + row_offset);
+    const float4* in_f4 = reinterpret_cast<const float4*>(input + row_offset);
+    const float4* w_f4 = reinterpret_cast<const float4*>(weight);
+    float4* out_f4 = reinterpret_cast<float4*>(norm_output + row_offset);
+
+    const int vec_count = dim / 8; // number of float4 elements
+
+    // Pass 1: residual += input, compute sum of squares
+    float sum = 0.0f;
+    for (int i = tid; i < vec_count; i += blockDim.x) {
+        float4 r = res_f4[i];
+        float4 inp = in_f4[i];
+
+        __nv_bfloat162* r_b2 = reinterpret_cast<__nv_bfloat162*>(&r);
+        const __nv_bfloat162* in_b2 = reinterpret_cast<const __nv_bfloat162*>(&inp);
+
+        #pragma unroll
+        for (int j = 0; j < 4; j++) {
+            r_b2[j] = __hadd2(r_b2[j], in_b2[j]);
+            float x0 = __bfloat162float(r_b2[j].x);
+            float x1 = __bfloat162float(r_b2[j].y);
+            sum += x0 * x0 + x1 * x1;
+        }
+
+        res_f4[i] = r; // write back residual += input
+    }
+
+    // Block reduce for sum of squares
+    typedef cub::BlockReduce<float, 128> BlockReduce;
+    __shared__ typename BlockReduce::TempStorage temp_storage;
+    float total_sum = BlockReduce(temp_storage).Sum(sum);
+
+    __shared__ float inv_rms;
+    if (tid == 0) {
+        inv_rms = rsqrtf(total_sum / float(dim) + eps);
+    }
+    __syncthreads();
+
+    // Pass 2: norm_output = residual * inv_rms * weight
+    float f_inv_rms = inv_rms;
+    for (int i = tid; i < vec_count; i += blockDim.x) {
+        float4 r = res_f4[i];
+        float4 w = w_f4[i];
+
+        __nv_bfloat162* r_b2 = reinterpret_cast<__nv_bfloat162*>(&r);
+        __nv_bfloat162* w_b2 = reinterpret_cast<__nv_bfloat162*>(&w);
+
+        __nv_bfloat162 scale = __floats2bfloat162_rn(f_inv_rms, f_inv_rms);
+
+        #pragma unroll
+        for (int j = 0; j < 4; j++) {
+            r_b2[j] = __hmul2(__hmul2(r_b2[j], scale), w_b2[j]);
+        }
+
+        out_f4[i] = r;
+    }
+}
+
+void fused_add_rmsnorm_kernel_cu_bf16(
+    __nv_bfloat16* norm_output,
+    __nv_bfloat16* residual,
+    const __nv_bfloat16* input,
+    const __nv_bfloat16* weight,
+    int rows, int dim, float eps,
+    cudaStream_t stream
+) {
+    constexpr int threads_num = 128;
+    fused_add_rmsnorm_bf16_kernel<<<rows, threads_num, 0, stream>>>(
+        norm_output, residual, input, weight, dim, eps
+    );
+}

--- a/crates/infer-core/src/op/kernels/cuda/rmsnorm/rmsnorm.h
+++ b/crates/infer-core/src/op/kernels/cuda/rmsnorm/rmsnorm.h
@@ -5,6 +5,15 @@ extern "C" {
 
 void rmsnorm_kernel_cu_dim(float*, float*, float*, int, int, float, CUstream_st*);
 void rmsnorm_kernel_cu_bf16x8(__nv_bfloat16* , __nv_bfloat16* , __nv_bfloat16* , int , int , float , CUstream_st*);
+void fused_add_rmsnorm_kernel_cu_bf16(
+    __nv_bfloat16* norm_output,
+    __nv_bfloat16* residual,
+    const __nv_bfloat16* input,
+    const __nv_bfloat16* weight,
+    int rows, int dim, float eps,
+    CUstream_st* stream
+);
+
 #ifdef __cplusplus
 }
 #endif

--- a/crates/infer-core/src/op/kernels/cuda/sampler/sampler.cu
+++ b/crates/infer-core/src/op/kernels/cuda/sampler/sampler.cu
@@ -30,26 +30,27 @@ void argmax_cu_f32_ffi(
 }
 
 
-// ------------------- BF16 版本 -------------------
+// ------------------- BF16 版本 (Two-phase parallel argmax) -------------------
 #include <cuda_bf16.h>
-#include <cub/cub.cuh> // 仅使用 BlockReduce，这是 header-only 的
+#include <cub/cub.cuh>
 
-// 1. 定义 Kernel
-__global__ void argmax_kernel_bf16(
-    const __nv_bfloat16* __restrict__ input, 
-    int n, 
-    int* __restrict__ output_idx
+// Static device arrays for inter-block communication
+__device__ float d_partial_vals[1024];
+__device__ int   d_partial_idxs[1024];
+
+// Phase 1: Each block reduces a chunk of the input, writes (max_val, max_idx) to d_partial_*
+__global__ void argmax_phase1_bf16(
+    const __nv_bfloat16* __restrict__ input,
+    int n
 ) {
     int tid = threadIdx.x;
     int gid = blockIdx.x * blockDim.x + threadIdx.x;
+    int stride = gridDim.x * blockDim.x;
 
-    // 每个线程维护当前的局部最大值和索引
-    // 初始化为极小值
-    float max_val = -3.40282e38f; // -FLT_MAX
+    float max_val = -3.40282e38f;
     int max_idx = -1;
 
-    // Grid-Stride Loop: 处理数据量 > 线程数的情况
-    for (int i = gid; i < n; i += gridDim.x * blockDim.x) {
+    for (int i = gid; i < n; i += stride) {
         float val = __bfloat162float(input[i]);
         if (val > max_val) {
             max_val = val;
@@ -57,51 +58,67 @@ __global__ void argmax_kernel_bf16(
         }
     }
 
-    // Block 内归约 (使用 CUB BlockReduce)
-    // 定义 Pair 类型: <数值, 索引>。注意 CUB ArgMax 默认找 Key 最大，我们这里需要自定义
-    // 为了简单，我们手动做 Block Reduce
-    
-    // 共享内存
     using BlockReduce = cub::BlockReduce<cub::KeyValuePair<int, float>, 256>;
     __shared__ typename BlockReduce::TempStorage temp_storage;
 
-    // 创建当前线程的 KV 对 (注意：CUB ArgMax 比较器有点绕，我们直接用 reduce 找最大 float)
-    // 更简单的办法：把 (val, idx) 作为一个对象，自定义 max 操作
-    
-    cub::KeyValuePair<int, float> thread_data;
-    thread_data.key = max_idx; // 索引
-    thread_data.value = max_val; // 数值
-
-    // 归约操作符：返回 Value 更大的那个；如果 Value 相等，返回 Key (Index) 更小的
+    cub::KeyValuePair<int, float> thread_data{max_idx, max_val};
     auto argmax_op = [](const cub::KeyValuePair<int, float>& a, const cub::KeyValuePair<int, float>& b) {
-        if (a.value != b.value) return (a.value > b.value) ? a : b;
-        return (a.key < b.key) ? a : b; // 索引越小越优先
+        return (a.value >= b.value) ? a : b;
     };
 
-    // 执行 Block Reduce
-    // 结果在 threadIdx.x == 0 的线程中
-    cub::KeyValuePair<int, float> block_result = BlockReduce(temp_storage).Reduce(thread_data, argmax_op);
+    auto block_result = BlockReduce(temp_storage).Reduce(thread_data, argmax_op);
 
-    // 2. Block 间归约 (由于 ArgMax 很难用 atomicMax 实现，
-    // 对于 LLM 的 vocab_size (比如 32000/128000)，通常一个 Block (256/1024线程) 就能处理完一行的 ArgMax)
-    // 所以这里我们可以只启动 **1个 Block** 即可！
-    
+    if (tid == 0) {
+        d_partial_vals[blockIdx.x] = block_result.value;
+        d_partial_idxs[blockIdx.x] = block_result.key;
+    }
+}
+
+// Phase 2: Single block reduces partial results → final answer
+__global__ void argmax_phase2(
+    int num_blocks,
+    int* __restrict__ output_idx
+) {
+    int tid = threadIdx.x;
+
+    float max_val = -3.40282e38f;
+    int max_idx = -1;
+
+    for (int i = tid; i < num_blocks; i += blockDim.x) {
+        float val = d_partial_vals[i];
+        if (val > max_val) {
+            max_val = val;
+            max_idx = d_partial_idxs[i];
+        }
+    }
+
+    using BlockReduce = cub::BlockReduce<cub::KeyValuePair<int, float>, 256>;
+    __shared__ typename BlockReduce::TempStorage temp_storage;
+
+    cub::KeyValuePair<int, float> thread_data{max_idx, max_val};
+    auto argmax_op = [](const cub::KeyValuePair<int, float>& a, const cub::KeyValuePair<int, float>& b) {
+        return (a.value >= b.value) ? a : b;
+    };
+
+    auto block_result = BlockReduce(temp_storage).Reduce(thread_data, argmax_op);
+
     if (tid == 0) {
         *output_idx = block_result.key;
     }
 }
 
 void argmax_cu_bf16_ffi(
-    const __nv_bfloat16* logits_ptr, 
+    const __nv_bfloat16* logits_ptr,
     int vocab_size,
-    int* result_ptr_gpu, 
+    int* result_ptr_gpu,
     cudaStream_t stream
 ) {
-    // 针对 LLM Vocab Size (e.g. 32k ~ 128k) 的优化配置
-    // 一个 Block 256 线程，每个线程处理约 128~500 个元素，效率很高，无需多 Block 级联
     const int threads = 256;
-    const int blocks = 1; 
+    // Each thread processes ~4 elements for good occupancy
+    int num_blocks = (vocab_size + threads * 4 - 1) / (threads * 4);
+    if (num_blocks > 1024) num_blocks = 1024;
+    if (num_blocks < 1) num_blocks = 1;
 
-    argmax_kernel_bf16<<<blocks, threads, 0, stream>>>(logits_ptr, vocab_size, result_ptr_gpu);
-
+    argmax_phase1_bf16<<<num_blocks, threads, 0, stream>>>(logits_ptr, vocab_size);
+    argmax_phase2<<<1, threads, 0, stream>>>(num_blocks, result_ptr_gpu);
 }

--- a/crates/infer-core/src/op/kernels/cuda/split_cols/mod.rs
+++ b/crates/infer-core/src/op/kernels/cuda/split_cols/mod.rs
@@ -1,0 +1,43 @@
+use crate::base::error::Result;
+use crate::cuda;
+use crate::tensor::Tensor;
+use std::ffi::c_void;
+
+unsafe extern "C" {
+    fn split_cols_bf16(
+        src: *const c_void,
+        dst: *mut c_void,
+        rows: i32,
+        total_cols: i32,
+        col_offset: i32,
+        dst_cols: i32,
+        stream: cuda::ffi::cudaStream_t,
+    );
+}
+
+/// Split columns from a fused [rows, total_cols] BF16 tensor.
+/// Copies columns [col_offset, col_offset + dst_cols) into dst [rows, dst_cols].
+pub fn split_cols_bf16_tensor(
+    src: &Tensor,
+    dst: &mut Tensor,
+    rows: usize,
+    total_cols: usize,
+    col_offset: usize,
+    dst_cols: usize,
+    stream: cuda::ffi::cudaStream_t,
+) -> Result<()> {
+    let src_ptr = src.as_bf16()?.buffer().as_ptr() as *const c_void;
+    let dst_ptr = dst.as_bf16_mut()?.buffer_mut().as_mut_ptr() as *mut c_void;
+    unsafe {
+        split_cols_bf16(
+            src_ptr,
+            dst_ptr,
+            rows as i32,
+            total_cols as i32,
+            col_offset as i32,
+            dst_cols as i32,
+            stream,
+        );
+    }
+    Ok(())
+}

--- a/crates/infer-core/src/op/kernels/cuda/split_cols/split_cols.cu
+++ b/crates/infer-core/src/op/kernels/cuda/split_cols/split_cols.cu
@@ -1,0 +1,38 @@
+#include <cuda_runtime.h>
+#include <cuda_bf16.h>
+
+/// Split columns from a [rows, total_cols] matrix into a [rows, dst_cols] matrix.
+/// Copies columns [col_offset, col_offset + dst_cols) from src to dst.
+__global__ void split_cols_bf16_kernel(
+    const __nv_bfloat16* __restrict__ src,
+    __nv_bfloat16* __restrict__ dst,
+    int rows,
+    int total_cols,
+    int col_offset,
+    int dst_cols
+) {
+    int idx = blockIdx.x * blockDim.x + threadIdx.x;
+    int total_elements = rows * dst_cols;
+    if (idx >= total_elements) return;
+
+    int r = idx / dst_cols;
+    int c = idx % dst_cols;
+    dst[idx] = src[r * total_cols + col_offset + c];
+}
+
+extern "C" void split_cols_bf16(
+    const __nv_bfloat16* src,
+    __nv_bfloat16* dst,
+    int rows,
+    int total_cols,
+    int col_offset,
+    int dst_cols,
+    cudaStream_t stream
+) {
+    int total_elements = rows * dst_cols;
+    int block_size = 256;
+    int grid_size = (total_elements + block_size - 1) / block_size;
+    split_cols_bf16_kernel<<<grid_size, block_size, 0, stream>>>(
+        src, dst, rows, total_cols, col_offset, dst_cols
+    );
+}

--- a/scripts/bench_vllm.py
+++ b/scripts/bench_vllm.py
@@ -1,0 +1,94 @@
+"""
+vLLM single-request latency benchmark for Qwen3-4B.
+Measures TTFT, TPOT, and total latency with token-level timing.
+"""
+import os
+import time
+import argparse
+
+# Disable torch.compile, keep CUDA graph enabled
+os.environ["VLLM_TORCH_COMPILE_LEVEL"] = "0"
+os.environ["VLLM_USE_V1"] = "0"  # V1 engine forces compile, fallback to V0
+
+from vllm import LLM, SamplingParams
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--model", type=str, default="/apdcephfs_qy2/share_303432435/vinciiliu/models/qwen3-4b-instruct")
+    parser.add_argument("--prompt", type=str, default="请用中文详细介绍二叉树的中序遍历算法，并给出Python实现代码。")
+    parser.add_argument("--max-tokens", type=int, default=512)
+    parser.add_argument("--dtype", type=str, default="bfloat16")
+    parser.add_argument("--warmup", type=int, default=3, help="warmup iterations")
+    args = parser.parse_args()
+
+    print(f"Loading model: {args.model}")
+    llm = LLM(
+        model=args.model,
+        dtype=args.dtype,
+        max_model_len=2048,
+        gpu_memory_utilization=0.9,
+        enforce_eager=False,  # enable CUDA graph
+    )
+
+    sampling_params = SamplingParams(
+        temperature=0.6,
+        top_p=0.95,
+        max_tokens=args.max_tokens,
+    )
+
+    # Warmup
+    print(f"Warming up ({args.warmup} iterations)...")
+    for i in range(args.warmup):
+        llm.generate([args.prompt], sampling_params)
+    print("Warmup done.\n")
+
+    # Benchmark
+    print("=" * 60)
+    print("Benchmark run")
+    print("=" * 60)
+
+    t_start = time.perf_counter()
+    outputs = llm.generate([args.prompt], sampling_params)
+    t_end = time.perf_counter()
+
+    output = outputs[0]
+    generated_text = output.outputs[0].text
+    num_prompt_tokens = len(output.prompt_token_ids)
+    num_output_tokens = len(output.outputs[0].token_ids)
+    total_time_ms = (t_end - t_start) * 1000
+
+    # Timing: approximate TTFT not available in offline mode, use total time
+    ttft_ms = None
+    decode_time_ms = None
+    tpot_ms = total_time_ms / max(num_output_tokens, 1)
+    metrics = getattr(output, 'metrics', None)
+    if metrics is not None:
+        ft = getattr(metrics, 'first_token_time', None)
+        st = getattr(metrics, 'first_scheduled_time', None)
+        fin = getattr(metrics, 'finished_time', None)
+        if ft and st:
+            ttft_ms = (ft - st) * 1000
+        if ft and fin:
+            decode_time_ms = (fin - ft) * 1000
+            tpot_ms = decode_time_ms / max(num_output_tokens - 1, 1)
+
+    print(f"\nPrompt ({num_prompt_tokens} tokens): {args.prompt[:80]}...")
+    print(f"\nGenerated ({num_output_tokens} tokens):\n{generated_text}\n")
+    print("=" * 60)
+    print(f"  Prompt tokens:    {num_prompt_tokens}")
+    print(f"  Output tokens:    {num_output_tokens}")
+    print(f"  Total time:       {total_time_ms:.1f} ms")
+    if ttft_ms is not None:
+        print(f"  TTFT:             {ttft_ms:.1f} ms")
+    if tpot_ms is not None:
+        print(f"  TPOT:             {tpot_ms:.2f} ms/token")
+    if decode_time_ms is not None:
+        print(f"  Decode time:      {decode_time_ms:.1f} ms")
+    throughput = num_output_tokens / (total_time_ms / 1000)
+    print(f"  Throughput:       {throughput:.1f} tokens/s")
+    print("=" * 60)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Decode throughput improved from 192 tok/s to 259 tok/s, surpassing vLLM (255 tok/s) on H20.

Optimizations:
- Fused QKV GEMM: 3 matmuls → 1 per layer (concat Wq/Wk/Wv at load time)
- Fused Gate-Up GEMM: 2 matmuls → 1 per layer (concat W1/W3 at load time)
- Zero-copy column slice for decode (seq_len=1): eliminate split_cols kernels, reducing CUDA Graph nodes and cudaGraphLaunch overhead (752µs → 90µs)
- Multi-block parallel argmax: replace single-block scan (202µs → 5µs)
- Fused add+rmsnorm kernel: merge residual add with rmsnorm in one pass, applied to both post-attention and post-FFN positions (cross-layer fusion)
- Add split_cols CUDA kernel for prefill column extraction
- Add vLLM benchmark script for fair comparison