### PR TITLE
Add one-command GPU container distribution

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,16 @@
+**
+
+!Cargo.toml
+!Cargo.lock
+!rust-toolchain.toml
+!LICENSE
+!Dockerfile
+!docker/
+!docker/**
+!crates/
+!crates/**
+
+crates/infer-frontend/node_modules/
+crates/infer-frontend/target/
+**/*.pyc
+**/__pycache__/

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,10 @@ jobs:
       - name: Check formatting
         run: cargo fmt --all -- --check
       - name: Audit Rust dependencies
-        run: cargo install cargo-audit --locked && cargo audit --deny warnings
+        # Axum's disabled multipart feature retains yanked spin 0.9.8 in the
+        # lockfile. Keep security advisories fatal while ignoring yanked-only
+        # warnings for dependencies that are not in the compiled graph.
+        run: cargo install cargo-audit --locked && cargo audit --no-yanked --deny warnings
       - name: Lint GPU-independent crates
         run: |
           cargo clippy -p infer-core -p infer-backend-cpu -p infer-protocol \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,7 +69,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Validate shell syntax
-        run: bash -n scripts/*.sh scripts/lib/*.sh bench/*.sh crates/infer-frontend/dev.sh
+        run: bash -n scripts/*.sh scripts/lib/*.sh docker/*.sh bench/*.sh crates/infer-frontend/dev.sh
       - name: Compile Python tools
         run: PYTHONPYCACHEPREFIX=/tmp/rustinfer-pyc python3 -m compileall -q bench scripts
       - name: Reject generated Python bytecode

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,104 @@
+name: Docker
+
+on:
+  push:
+    tags:
+      - "v*"
+  workflow_dispatch:
+    inputs:
+      image_tag:
+        description: Image tag for a manual build
+        required: true
+        default: dev
+        type: string
+      cuda_arch:
+        description: CUDA architecture compiled into the image
+        required: true
+        default: sm_90
+        type: choice
+        options:
+          - sm_90
+          - sm_89
+          - sm_86
+          - sm_80
+
+permissions:
+  contents: read
+  packages: write
+  attestations: write
+  id-token: write
+
+concurrency:
+  group: docker-${{ github.ref }}
+  cancel-in-progress: false
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  image:
+    name: CUDA image
+    runs-on: ubuntu-24.04
+    timeout-minutes: 120
+    steps:
+      - uses: actions/checkout@v4
+
+      # Standard public-repository runners are free but expose only 14 GB of
+      # SSD. Remove unrelated preinstalled SDKs from this disposable VM before
+      # pulling the CUDA devel/runtime images.
+      - name: Reclaim runner disk space
+        run: |
+          sudo rm -rf \
+            /opt/ghc \
+            /opt/hostedtoolcache/CodeQL \
+            /usr/local/lib/android \
+            /usr/share/dotnet
+          df -h /
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Generate image metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/v') }}
+            type=raw,value=${{ inputs.image_tag }},enable=${{ github.event_name == 'workflow_dispatch' }}
+
+      - name: Build and publish
+        id: push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: Dockerfile
+          platforms: linux/amd64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            CUDA_ARCH=${{ inputs.cuda_arch || 'sm_90' }}
+            VERSION=${{ steps.meta.outputs.version }}
+            VCS_REF=${{ github.sha }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          provenance: true
+          sbom: true
+
+      - name: Attest image
+        uses: actions/attest-build-provenance@v2
+        with:
+          subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          subject-digest: ${{ steps.push.outputs.digest }}
+          push-to-registry: true

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,135 @@
+# syntax=docker/dockerfile:1.7
+
+ARG CUDA_VERSION=12.8.1
+ARG UBUNTU_VERSION=24.04
+
+FROM nvidia/cuda:${CUDA_VERSION}-cudnn-devel-ubuntu${UBUNTU_VERSION} AS builder
+
+ARG RUST_VERSION=1.91.1
+ARG CUDA_ARCH=sm_90
+ARG CUDNN_FRONTEND_VERSION=1.18.0
+
+ENV DEBIAN_FRONTEND=noninteractive \
+    CARGO_HOME=/opt/cargo \
+    RUSTUP_HOME=/opt/rustup \
+    PATH=/opt/cargo/bin:${PATH}
+
+RUN apt-get update \
+    && apt-get install --yes --no-install-recommends \
+        build-essential \
+        ca-certificates \
+        clang \
+        cmake \
+        curl \
+        libclang-dev \
+        pkg-config \
+        python3 \
+        python3-pip \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN curl --proto '=https' --tlsv1.2 --fail --silent --show-error \
+        --output /tmp/rustup-init \
+        https://sh.rustup.rs \
+    && chmod 0755 /tmp/rustup-init \
+    && /tmp/rustup-init \
+        --default-toolchain "${RUST_VERSION}" \
+        --profile minimal \
+        --no-modify-path \
+        --yes \
+    && rm /tmp/rustup-init \
+    && rustc --version \
+    && cargo --version
+
+# RustInfer includes cuDNN Frontend headers from this wheel. They are only
+# required while compiling the CUDA kernels and are not copied to the runtime.
+RUN python3 -m pip install \
+        --break-system-packages \
+        --no-cache-dir \
+        --no-deps \
+        "nvidia_cudnn_frontend==${CUDNN_FRONTEND_VERSION}" \
+    && frontend_include="$(python3 -c \
+        'import site; print(site.getsitepackages()[0] + "/include")')" \
+    && test -f "${frontend_include}/cudnn_frontend.h" \
+    && ln -s "${frontend_include}" /opt/cudnn-frontend
+
+ENV CUDA_ARCH=${CUDA_ARCH} \
+    CUDNN_FRONTEND_INCLUDE_DIR=/opt/cudnn-frontend
+
+WORKDIR /src
+
+COPY Cargo.toml Cargo.lock rust-toolchain.toml ./
+COPY crates ./crates
+
+RUN cargo build \
+        --locked \
+        --release \
+        -p infer-worker \
+        -p infer-scheduler \
+        -p infer-server \
+    && strip \
+        target/release/rustinfer-worker \
+        target/release/rustinfer-scheduler \
+        target/release/rustinfer-server
+
+FROM nvidia/cuda:${CUDA_VERSION}-cudnn-runtime-ubuntu${UBUNTU_VERSION} AS runtime
+
+ARG CUDA_ARCH=sm_90
+ARG VERSION=dev
+ARG VCS_REF=unknown
+
+LABEL org.opencontainers.image.title="RustInfer" \
+      org.opencontainers.image.description="RustInfer OpenAI-compatible CUDA inference server" \
+      org.opencontainers.image.source="https://github.com/Vinci-hit/RustInfer" \
+      org.opencontainers.image.licenses="Apache-2.0" \
+      org.opencontainers.image.version="${VERSION}" \
+      org.opencontainers.image.revision="${VCS_REF}"
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update \
+    && apt-get install --yes --no-install-recommends \
+        ca-certificates \
+        curl \
+        libstdc++6 \
+        tini \
+    && rm -rf /var/lib/apt/lists/* \
+    && useradd \
+        --create-home \
+        --home-dir /home/rustinfer \
+        --shell /usr/sbin/nologin \
+        --uid 10001 \
+        --user-group \
+        rustinfer \
+    && install -d -o rustinfer -g rustinfer /models /opt/rustinfer
+
+COPY --from=builder /src/target/release/rustinfer-worker /usr/local/bin/
+COPY --from=builder /src/target/release/rustinfer-scheduler /usr/local/bin/
+COPY --from=builder /src/target/release/rustinfer-server /usr/local/bin/
+COPY docker/entrypoint.sh /usr/local/bin/rustinfer-container
+COPY LICENSE /usr/share/licenses/rustinfer/LICENSE
+COPY crates/infer-backend-cuda/src/kernels/third_party/fa3/LICENSE \
+    /usr/share/licenses/rustinfer/FA3-LICENSE
+
+RUN chmod 0755 /usr/local/bin/rustinfer-container
+
+ENV NVIDIA_VISIBLE_DEVICES=all \
+    NVIDIA_DRIVER_CAPABILITIES=compute,utility \
+    RUSTINFER_CUDA_ARCH=${CUDA_ARCH} \
+    RUSTINFER_MODEL=/models/model \
+    RUSTINFER_HOST=0.0.0.0 \
+    RUSTINFER_PORT=8000
+
+USER rustinfer
+WORKDIR /opt/rustinfer
+
+EXPOSE 8000
+VOLUME ["/models"]
+
+HEALTHCHECK --interval=15s --timeout=5s --start-period=300s --retries=4 \
+    CMD port="$(cat /tmp/rustinfer-port 2>/dev/null || printf '%s' "${RUSTINFER_PORT}")"; \
+        curl --fail --silent --show-error \
+        "http://127.0.0.1:${port}/ready" >/dev/null || exit 1
+
+STOPSIGNAL SIGTERM
+ENTRYPOINT ["/usr/bin/tini", "--", "/usr/local/bin/rustinfer-container"]
+CMD ["serve"]

--- a/README.md
+++ b/README.md
@@ -151,7 +151,61 @@ ZMQ (IPC) with MessagePack framing:
 
 ## Quick start
 
-### Prerequisites
+### Docker (H100 / H200)
+
+The runtime image contains the compiled CUDA kernels, CUDA 12 runtime, cuBLAS,
+and cuDNN. The host only needs a compatible NVIDIA driver, Docker, and the
+NVIDIA Container Toolkit; Rust, `nvcc`, libclang, and cuDNN headers are not
+required.
+
+Build the image once (the default `sm_90` target is for H100/H200):
+
+```bash
+DOCKER_BUILDKIT=1 docker build \
+  --build-arg CUDA_ARCH=sm_90 \
+  -t rustinfer:local .
+```
+
+Start the full scheduler + worker + server stack with one command. The mounted
+directory must be a Hugging Face model directory containing `config.json`,
+`tokenizer.json`, and the model weights:
+
+```bash
+docker run --rm --gpus all \
+  -p 8000:8000 \
+  -v /absolute/path/to/Qwen3:/models/model:ro \
+  rustinfer:local
+```
+
+Check readiness:
+
+```bash
+curl --fail http://127.0.0.1:8000/ready
+```
+
+The container also accepts explicit launch options:
+
+```bash
+docker run --rm --gpus all \
+  -p 8100:8100 \
+  -v /absolute/path/to/Qwen3:/models/qwen3:ro \
+  rustinfer:local \
+  serve --model /models/qwen3 --model-name Qwen3 --port 8100
+```
+
+Release tags publish the same image to
+`ghcr.io/vinci-hit/rustinfer:<version>`. Images are architecture-specific;
+build with `CUDA_ARCH=sm_80`, `sm_86`, or `sm_89` for other supported GPUs and
+tag the result accordingly.
+
+Useful container settings include `RUSTINFER_MAX_BATCH_TOKENS`,
+`RUSTINFER_MAX_BATCH_SEQS`, `RUSTINFER_MAX_MODEL_LEN`,
+`RUSTINFER_CHUNKED_PREFILL_SIZE`, and `RUST_LOG`. A complete custom config can
+instead be mounted and selected with `--config`.
+
+### Build from source
+
+#### Prerequisites
 
 - Rustup (the repository pins Rust 1.91.1), a CUDA-capable GPU, and the CUDA
   toolkit.
@@ -161,13 +215,13 @@ ZMQ (IPC) with MessagePack framing:
 export CUDNN_FRONTEND_INCLUDE_DIR=/path/to/site-packages/include
 ```
 
-### Build
+#### Build
 
 ```bash
 cargo build --release
 ```
 
-### Run (one-shot e2e smoke test)
+#### Run (one-shot e2e smoke test)
 
 Launches scheduler + worker + server for a config, sends one chat completion,
 prints the reply, and tears everything down:
@@ -180,7 +234,7 @@ The checked-in configs are portable templates. Set their `model` field to the
 local Hugging Face model directory before launching; they bind to
 `127.0.0.1` and use `cuda:0` by default.
 
-### Run (manual, three processes)
+#### Run (manual, three processes)
 
 Each binary takes the same `--config`:
 
@@ -202,7 +256,7 @@ curl http://127.0.0.1:8100/v1/chat/completions \
 Ready-to-use configs: `run_qwen3.toml`, `run_qwen3_awq.toml` (AWQ int4),
 `run_llama1b.toml`.
 
-### Python benchmark tools
+#### Python benchmark tools
 
 The Python project keeps benchmark dependencies optional so building RustInfer
 does not install another inference engine. Install only the group a script uses:

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,0 +1,260 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+usage() {
+    cat <<'EOF'
+Usage:
+  rustinfer-container serve [options]
+  rustinfer-container <command> [args...]
+
+Options:
+  --model PATH       Model directory inside the container.
+  --model-name NAME  Name exposed by the OpenAI-compatible API.
+  --device DEVICE    CUDA device, default: cuda:0.
+  --host HOST        HTTP bind address, default: 0.0.0.0.
+  --port PORT        HTTP port, default: 8000.
+  --config PATH      Use a complete mounted TOML config instead of generating one.
+  -h, --help         Show this help.
+
+The same values can be supplied with RUSTINFER_MODEL, RUSTINFER_MODEL_NAME,
+RUSTINFER_DEVICE, RUSTINFER_HOST, RUSTINFER_PORT, and RUSTINFER_CONFIG.
+EOF
+}
+
+require_value() {
+    local option="$1"
+    local value="${2:-}"
+    if [[ -z "$value" ]]; then
+        echo "Missing value for ${option}" >&2
+        exit 2
+    fi
+}
+
+toml_escape() {
+    local value="$1"
+    if [[ "$value" == *$'\n'* || "$value" == *$'\r'* ]]; then
+        echo "TOML string values cannot contain newlines" >&2
+        exit 2
+    fi
+    value="${value//\\/\\\\}"
+    value="${value//\"/\\\"}"
+    printf '%s' "$value"
+}
+
+validate_uint() {
+    local name="$1"
+    local value="$2"
+    if [[ ! "$value" =~ ^[0-9]+$ ]]; then
+        echo "${name} must be an unsigned integer, got: ${value}" >&2
+        exit 2
+    fi
+}
+
+if [[ "${1:-}" == "-h" || "${1:-}" == "--help" ]]; then
+    usage
+    exit 0
+fi
+
+# Preserve normal container debugging: `docker run ... bash` or an explicit
+# RustInfer binary bypasses the supervisor.
+if [[ -n "${1:-}" && "${1}" != "serve" && "${1}" != --* ]]; then
+    exec "$@"
+fi
+if [[ "${1:-}" == "serve" ]]; then
+    shift
+fi
+
+model="${RUSTINFER_MODEL:-/models/model}"
+model_name="${RUSTINFER_MODEL_NAME:-}"
+device="${RUSTINFER_DEVICE:-cuda:0}"
+host="${RUSTINFER_HOST:-0.0.0.0}"
+port="${RUSTINFER_PORT:-8000}"
+config="${RUSTINFER_CONFIG:-}"
+
+while (($# > 0)); do
+    case "$1" in
+        --model)
+            require_value "$1" "${2:-}"
+            model="$2"
+            shift 2
+            ;;
+        --model-name)
+            require_value "$1" "${2:-}"
+            model_name="$2"
+            shift 2
+            ;;
+        --device)
+            require_value "$1" "${2:-}"
+            device="$2"
+            shift 2
+            ;;
+        --host)
+            require_value "$1" "${2:-}"
+            host="$2"
+            shift 2
+            ;;
+        --port)
+            require_value "$1" "${2:-}"
+            port="$2"
+            shift 2
+            ;;
+        --config)
+            require_value "$1" "${2:-}"
+            config="$2"
+            shift 2
+            ;;
+        -h|--help)
+            usage
+            exit 0
+            ;;
+        *)
+            echo "Unknown option: $1" >&2
+            usage >&2
+            exit 2
+            ;;
+    esac
+done
+
+validate_uint "port" "$port"
+if ((port == 0 || port > 65535)); then
+    echo "port must be between 1 and 65535, got: ${port}" >&2
+    exit 2
+fi
+
+cluster_id="${RUSTINFER_CLUSTER_ID:-rustinfer}"
+if [[ ! "$cluster_id" =~ ^[A-Za-z0-9_.-]+$ ]]; then
+    echo "RUSTINFER_CLUSTER_ID may contain only letters, digits, '.', '_' and '-'" >&2
+    exit 2
+fi
+
+if [[ -n "$config" ]]; then
+    if [[ ! -f "$config" ]]; then
+        echo "Config file not found: ${config}" >&2
+        exit 2
+    fi
+else
+    if [[ ! -d "$model" ]]; then
+        echo "Model directory not found: ${model}" >&2
+        echo "Mount a Hugging Face model directory at /models/model or pass --model." >&2
+        exit 2
+    fi
+    for required_file in config.json tokenizer.json; do
+        if [[ ! -f "${model}/${required_file}" ]]; then
+            echo "Model directory is missing ${required_file}: ${model}" >&2
+            exit 2
+        fi
+    done
+
+    max_batch_tokens="${RUSTINFER_MAX_BATCH_TOKENS:-4096}"
+    max_batch_seqs="${RUSTINFER_MAX_BATCH_SEQS:-32}"
+    max_model_len="${RUSTINFER_MAX_MODEL_LEN:-4096}"
+    chunked_prefill_size="${RUSTINFER_CHUNKED_PREFILL_SIZE:-256}"
+    request_timeout_secs="${RUSTINFER_REQUEST_TIMEOUT_SECS:-600}"
+    for numeric_setting in \
+        "RUSTINFER_MAX_BATCH_TOKENS:${max_batch_tokens}" \
+        "RUSTINFER_MAX_BATCH_SEQS:${max_batch_seqs}" \
+        "RUSTINFER_MAX_MODEL_LEN:${max_model_len}" \
+        "RUSTINFER_CHUNKED_PREFILL_SIZE:${chunked_prefill_size}" \
+        "RUSTINFER_REQUEST_TIMEOUT_SECS:${request_timeout_secs}"; do
+        validate_uint "${numeric_setting%%:*}" "${numeric_setting#*:}"
+    done
+
+    config="/tmp/rustinfer-container.toml"
+    cat >"$config" <<EOF
+model = "$(toml_escape "$model")"
+model_name = "$(toml_escape "$model_name")"
+cluster_id = "$(toml_escape "$cluster_id")"
+device = "$(toml_escape "$device")"
+host = "$(toml_escape "$host")"
+port = ${port}
+request_timeout_secs = ${request_timeout_secs}
+max_batch_tokens = ${max_batch_tokens}
+max_batch_seqs = ${max_batch_seqs}
+max_model_len = ${max_model_len}
+batch_wait_ms = 0
+paged_block_size = 1
+chunked_prefill_size = ${chunked_prefill_size}
+enable_prefix_caching = false
+mem_fraction_static = 0.85
+num_blocks = 0
+ignore_eos = false
+mode = "llm"
+worker_id = "worker-0"
+log_level = "$(toml_escape "${RUST_LOG:-info}")"
+capture_sizes = [1, 2, 4, 8, 16, 24, 32]
+EOF
+fi
+
+for socket in \
+    "/tmp/rustinfer-${cluster_id}-frontend.ipc" \
+    "/tmp/rustinfer-${cluster_id}-worker-in.ipc" \
+    "/tmp/rustinfer-${cluster_id}-worker-out.ipc" \
+    "/tmp/rustinfer-${cluster_id}-worker-control.ipc"; do
+    rm -f "$socket"
+done
+
+echo "RustInfer container starting"
+echo "  build CUDA arch: ${RUSTINFER_CUDA_ARCH:-unknown}"
+echo "  config:          ${config}"
+echo "  API:             http://${host}:${port}"
+printf '%s' "$port" >/tmp/rustinfer-port
+
+pids=()
+
+terminate_children() {
+    trap - TERM INT
+    local pid
+    for pid in "${pids[@]}"; do
+        if kill -0 "$pid" 2>/dev/null; then
+            kill -TERM "$pid" 2>/dev/null || true
+        fi
+    done
+
+    local attempt
+    for attempt in {1..50}; do
+        local running=false
+        for pid in "${pids[@]}"; do
+            if kill -0 "$pid" 2>/dev/null; then
+                running=true
+                break
+            fi
+        done
+        [[ "$running" == false ]] && break
+        sleep 0.1
+    done
+
+    for pid in "${pids[@]}"; do
+        if kill -0 "$pid" 2>/dev/null; then
+            kill -KILL "$pid" 2>/dev/null || true
+        fi
+        wait "$pid" 2>/dev/null || true
+    done
+}
+
+on_signal() {
+    echo "RustInfer container stopping"
+    terminate_children
+    exit 143
+}
+
+trap on_signal TERM INT
+
+rustinfer-scheduler --config "$config" &
+pids+=("$!")
+rustinfer-worker --config "$config" &
+pids+=("$!")
+rustinfer-server --config "$config" &
+pids+=("$!")
+
+set +e
+wait -n "${pids[@]}"
+status=$?
+set -e
+
+echo "A RustInfer process exited with status ${status}; stopping the container" >&2
+terminate_children
+if ((status == 0)); then
+    exit 1
+fi
+exit "$status"


### PR DESCRIPTION
## What changed

- add a multi-stage CUDA 12.8.1 Docker image for SM90
- add a container supervisor for scheduler, worker, and server
- generate launch configuration from container arguments and environment variables
- add readiness health checks and graceful shutdown
- publish tagged images to GHCR with SBOM and provenance
- reclaim space on the free public GitHub runner before CUDA builds
- document local and GHCR usage

## Why

Users should be able to run RustInfer without installing Rust, nvcc, libclang, or cuDNN development headers, and maintainers without local Docker privileges need a free hosted build path.

## Validation

- `bash -n` for repository shell scripts and the container entrypoint
- parsed both workflow files as YAML
- `git diff --check`
- `cargo fmt --all -- --check`
- exercised generated TOML and supervisor failure propagation with mocked child processes
- verified CUDA 12.8.1 cuDNN devel/runtime image manifests