### PR TITLE
Fix non-interactive rustup in Docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,7 +35,7 @@ RUN curl --proto '=https' --tlsv1.2 --fail --silent --show-error \
         --default-toolchain "${RUST_VERSION}" \
         --profile minimal \
         --no-modify-path \
-        --yes \
+        -y \
     && rm /tmp/rustup-init \
     && rustc --version \
     && cargo --version


### PR DESCRIPTION
## Summary
- use rustup supported short yes flag during non-interactive image builds

## Evidence
- GitHub Actions build 30604050397 reached the builder stage and failed because rustup requested the short yes flag
- git diff --check passes

## Follow-up
After merge, rerun the Docker workflow for version 1.0.1 with CUDA architecture sm_90.