### PR TITLE
feat(mtp): add Qwen3.5 speculative decoding, reusable workspaces and execution metrics

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,6 +75,8 @@ jobs:
         run: bash -n scripts/*.sh scripts/lib/*.sh docker/*.sh bench/*.sh crates/infer-frontend/dev.sh
       - name: Compile Python tools
         run: PYTHONPYCACHEPREFIX=/tmp/rustinfer-pyc python3 -m compileall -q bench scripts
+      - name: Test execution statistics tools
+        run: PYTHONPYCACHEPREFIX=/tmp/rustinfer-pyc python3 -m unittest discover -s scripts/tests -v
       - name: Reject generated Python bytecode
         run: test -z "$(find . -type f \( -name '*.pyc' -o -name '*.pyo' \) -print -quit)"
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1769,9 +1769,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.15"
+version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6cb093c84e8bd9b188d4c4a8cb6579fc016968d14c99882163cd3ff402a4f155"
+checksum = "a9f37a958b41b3b19ee2707c06439c0e9e547e847223eb791ecb0cb821c65e27"
 dependencies = [
  "atomic-waker",
  "bytes",

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,12 +2,15 @@
 
 ARG CUDA_VERSION=12.8.1
 ARG UBUNTU_VERSION=24.04
+# Keep development and runtime NCCL packages aligned with the CUDA base image.
+ARG NCCL_VERSION=2.25.1-1+cuda12.8
 
 FROM nvidia/cuda:${CUDA_VERSION}-cudnn-devel-ubuntu${UBUNTU_VERSION} AS builder
 
 ARG RUST_VERSION=1.91.1
 ARG CUDA_ARCH=sm_90
 ARG CUDNN_FRONTEND_VERSION=1.18.0
+ARG NCCL_VERSION
 
 ENV DEBIAN_FRONTEND=noninteractive \
     CARGO_HOME=/opt/cargo \
@@ -22,7 +25,7 @@ RUN apt-get update \
         cmake \
         curl \
         libclang-dev \
-        libnccl-dev \
+        libnccl-dev=${NCCL_VERSION} \
         pkg-config \
         python3 \
         python3-pip \
@@ -80,6 +83,7 @@ FROM nvidia/cuda:${CUDA_VERSION}-cudnn-runtime-ubuntu${UBUNTU_VERSION} AS runtim
 
 ARG CUDA_ARCH=sm_90
 ARG VERSION=dev
+ARG NCCL_VERSION
 ARG VCS_REF=unknown
 
 LABEL org.opencontainers.image.title="RustInfer" \
@@ -95,7 +99,7 @@ RUN apt-get update \
     && apt-get install --yes --no-install-recommends \
         ca-certificates \
         curl \
-        libnccl2 \
+        libnccl2=${NCCL_VERSION} \
         libstdc++6 \
         tini \
     && rm -rf /var/lib/apt/lists/* \

--- a/README.md
+++ b/README.md
@@ -301,6 +301,7 @@ Config is a single TOML shared by all three processes. Key fields:
 | `mem_fraction_static`   | Fraction of GPU memory reserved for weights + static buffers. |
 | `num_blocks`            | KV-cache blocks (`0` = auto-size from a memory profile). |
 | `capture_sizes`         | Batch sizes to capture CUDA graphs for, e.g. `[1,2,4,8,16,24,32]`. |
+| `mtp_num_draft_tokens`  | Opt-in Qwen3.5 text MTP; `0` disables it. Requires greedy sampling, TP1, `max_batch_seqs=1`, and prefix caching disabled. Verification runs eager. |
 | `ignore_eos`            | Ignore EOS (useful for fixed-length benchmarking). |
 
 ### Tensor parallelism

--- a/crates/infer-backend-cpu/src/lib.rs
+++ b/crates/infer-backend-cpu/src/lib.rs
@@ -725,6 +725,59 @@ impl CoreOps for Cpu {
         Ok(())
     }
 
+    fn concat_cols<T: Dtype>(
+        a: &Tensor<T, Self>,
+        b: &Tensor<T, Self>,
+        dst: &mut Tensor<T, Self>,
+    ) -> OpResult<()> {
+        let sa = a.shape().as_slice();
+        let sb = b.shape().as_slice();
+        let sd = dst.shape().as_slice();
+        if sa.len() != 2
+            || sb.len() != 2
+            || sd.len() != 2
+            || sa[0] != sb[0]
+            || sd[0] != sa[0]
+            || sa[1].checked_add(sb[1]) != Some(sd[1])
+            || !a.is_contiguous()
+            || !b.is_contiguous()
+            || !dst.is_contiguous()
+        {
+            return Err(OpError::Shape(
+                "concat_cols requires contiguous [N,A], [N,B], [N,A+B]".into(),
+            ));
+        }
+        let (rows, ac, bc, dc) = (sa[0], sa[1], sb[1], sd[1]);
+        if rows == 0 || dc == 0 {
+            return Ok(());
+        }
+        let dst_start = dst.data_ptr() as usize;
+        let dst_end = dst_start + dst.numel() * T::SIZE_BYTES;
+        for src in [a, b] {
+            let start = src.data_ptr() as usize;
+            let end = start + src.numel() * T::SIZE_BYTES;
+            if start < dst_end && dst_start < end {
+                return Err(OpError::Shape("concat_cols output overlaps input".into()));
+            }
+        }
+        for r in 0..rows {
+            // SAFETY: validated contiguous shapes and disjoint output above.
+            unsafe {
+                std::ptr::copy_nonoverlapping(
+                    a.data_ptr().add(r * ac),
+                    dst.data_ptr_mut().add(r * dc),
+                    ac,
+                );
+                std::ptr::copy_nonoverlapping(
+                    b.data_ptr().add(r * bc),
+                    dst.data_ptr_mut().add(r * dc + ac),
+                    bc,
+                );
+            }
+        }
+        Ok(())
+    }
+
     fn concat_seq<T: Dtype>(
         _a: &Tensor<T, Self>,
         _b: &Tensor<T, Self>,
@@ -1314,6 +1367,26 @@ fn check_numel3<T: Dtype, D: MemoryPort>(
 
 #[cfg(test)]
 mod tests {
+    #[test]
+    fn concat_cols_preserves_row_order_and_rejects_aliases() {
+        let device = Cpu;
+        let a = Tensor::from_host_slice(&[1f32, 2., 3., 4.], [2, 2], &device).unwrap();
+        let b = Tensor::from_host_slice(&[10f32, 20.], [2, 1], &device).unwrap();
+        let mut dst = Tensor::zeros([2, 3], &device).unwrap();
+        <Cpu as CoreOps>::concat_cols(&a, &b, &mut dst).unwrap();
+        assert_eq!(dst.to_host_vec().unwrap(), [1., 2., 10., 3., 4., 20.]);
+        let a = a.narrow(1, 0, 1).unwrap();
+        assert!(<Cpu as CoreOps>::concat_cols(&a, &b, &mut dst).is_err());
+        let a = dst.narrow(0, 0, 1).unwrap();
+        let empty = Tensor::zeros([1, 0], &device).unwrap();
+        let mut overlap = a.clone();
+        assert!(<Cpu as CoreOps>::concat_cols(&a, &empty, &mut overlap).is_err());
+        let a = Tensor::<f32, _>::zeros([0, 2], &device).unwrap();
+        let b = Tensor::zeros([0, 1], &device).unwrap();
+        let mut dst = Tensor::zeros([0, 3], &device).unwrap();
+        <Cpu as CoreOps>::concat_cols(&a, &b, &mut dst).unwrap();
+    }
+
     use super::*;
     use infer_core::ports::FusedOps;
     use infer_core::storage::Storage;

--- a/crates/infer-backend-cuda/build.rs
+++ b/crates/infer-backend-cuda/build.rs
@@ -220,6 +220,7 @@ fn main() {
             .allowlist_function("cudaFree")
             .allowlist_function("cudaMemcpy")
             .allowlist_function("cudaMemcpyAsync")
+            .allowlist_function("cudaMemcpy2DAsync")
             .allowlist_function("cudaMemset")
             .allowlist_function("cudaMemsetAsync")
             .allowlist_function("cudaHostRegister")

--- a/crates/infer-backend-cuda/build.rs
+++ b/crates/infer-backend-cuda/build.rs
@@ -244,6 +244,7 @@ fn main() {
             .allowlist_function("cudaEventCreateWithFlags")
             .allowlist_function("cudaEventRecord")
             .allowlist_function("cudaEventSynchronize")
+            .allowlist_function("cudaEventQuery")
             .allowlist_function("cudaEventElapsedTime")
             .allowlist_function("cudaEventDestroy")
             .allowlist_type("cudaEvent_t")

--- a/crates/infer-backend-cuda/src/kernels/concat_seq.rs
+++ b/crates/infer-backend-cuda/src/kernels/concat_seq.rs
@@ -73,8 +73,94 @@ pub fn concat_seq_into<T: Dtype>(
     Ok(())
 }
 
+/// Concatenate columns using two pitched, stream-ordered device copies.
+pub fn concat_cols_into<T: Dtype>(
+    stream: cudaStream_t,
+    a: &Tensor<T, Cuda>,
+    b: &Tensor<T, Cuda>,
+    dst: &mut Tensor<T, Cuda>,
+) -> OpResult<()> {
+    let sa = a.shape().as_slice();
+    let sb = b.shape().as_slice();
+    let sd = dst.shape().as_slice();
+    if sa.len() != 2
+        || sb.len() != 2
+        || sd.len() != 2
+        || sa[0] != sb[0]
+        || sd[0] != sa[0]
+        || sa[1].checked_add(sb[1]) != Some(sd[1])
+        || !a.is_contiguous()
+        || !b.is_contiguous()
+        || !dst.is_contiguous()
+    {
+        return Err(OpError::Shape(
+            "concat_cols requires contiguous [N,A], [N,B], [N,A+B]".into(),
+        ));
+    }
+    let (rows, ac, bc, dc) = (sa[0], sa[1], sb[1], sd[1]);
+    if rows == 0 || dc == 0 {
+        return Ok(());
+    }
+    let dst_start = dst.data_ptr() as usize;
+    let dst_end = dst_start + dst.numel() * T::SIZE_BYTES;
+    for src in [a, b] {
+        let start = src.data_ptr() as usize;
+        let end = start + src.numel() * T::SIZE_BYTES;
+        if start < dst_end && dst_start < end {
+            return Err(OpError::Shape("concat_cols output overlaps input".into()));
+        }
+    }
+    if a.device().device_id != b.device().device_id
+        || a.device().device_id != dst.device().device_id
+    {
+        return Err(OpError::Shape("concat_cols device mismatch".into()));
+    }
+    for (src, cols, offset) in [(a, ac, 0), (b, bc, ac)] {
+        if cols == 0 {
+            continue;
+        }
+        // SAFETY: validated disjoint contiguous matrices; pitch and extent fit each row.
+        let code = unsafe {
+            crate::ffi::cudaMemcpy2DAsync(
+                dst.data_ptr_mut().add(offset).cast(),
+                dc * T::SIZE_BYTES,
+                src.data_ptr().cast(),
+                cols * T::SIZE_BYTES,
+                cols * T::SIZE_BYTES,
+                rows,
+                cudaMemcpyKind::cudaMemcpyDeviceToDevice,
+                stream,
+            )
+        };
+        if code != cudaError_cudaSuccess {
+            return Err(crate::error::classify_sync_error(code, "concat_cols"));
+        }
+    }
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
+    #[test]
+    fn concat_cols_preserves_row_order_and_rejects_aliases() {
+        let device = Cuda::new(0).unwrap();
+        let a = Tensor::from_host_slice(&[1f32, 2., 3., 4.], [2, 2], &device).unwrap();
+        let b = Tensor::from_host_slice(&[10f32, 20.], [2, 1], &device).unwrap();
+        let mut dst = Tensor::zeros([2, 3], &device).unwrap();
+        concat_cols_into(device.config.stream, &a, &b, &mut dst).unwrap();
+        assert_eq!(dst.to_host_vec().unwrap(), [1., 2., 10., 3., 4., 20.]);
+        let a = a.narrow(1, 0, 1).unwrap();
+        assert!(concat_cols_into(device.config.stream, &a, &b, &mut dst).is_err());
+        let a = dst.narrow(0, 0, 1).unwrap();
+        let empty = Tensor::zeros([1, 0], &device).unwrap();
+        let mut overlap = a.clone();
+        assert!(concat_cols_into(device.config.stream, &a, &empty, &mut overlap).is_err());
+        let a = Tensor::<f32, _>::zeros([0, 2], &device).unwrap();
+        let b = Tensor::zeros([0, 1], &device).unwrap();
+        let mut dst = Tensor::zeros([0, 3], &device).unwrap();
+        concat_cols_into(device.config.stream, &a, &b, &mut dst).unwrap();
+    }
+
     use super::*;
     use half::bf16;
 
@@ -134,5 +220,38 @@ mod tests {
             OpError::Shape(_) => {}
             other => panic!("got {:?}", other),
         }
+    }
+}
+
+#[cfg(test)]
+mod column_dtype_tests {
+    use super::*;
+    #[test]
+    fn concat_cols_bf16() {
+        use half::bf16;
+        let device = Cuda::new(0).unwrap();
+        let a = Tensor::from_host_slice(&[bf16::from_f32(1.), bf16::from_f32(2.)], [2, 1], &device)
+            .unwrap();
+        let b = Tensor::from_host_slice(
+            &[
+                bf16::from_f32(3.),
+                bf16::from_f32(4.),
+                bf16::from_f32(5.),
+                bf16::from_f32(6.),
+            ],
+            [2, 2],
+            &device,
+        )
+        .unwrap();
+        let mut dst = Tensor::zeros([2, 3], &device).unwrap();
+        concat_cols_into(device.config.stream, &a, &b, &mut dst).unwrap();
+        assert_eq!(
+            dst.to_host_vec()
+                .unwrap()
+                .iter()
+                .map(|v| v.to_f32())
+                .collect::<Vec<_>>(),
+            [1., 3., 4., 2., 5., 6.]
+        );
     }
 }

--- a/crates/infer-backend-cuda/src/lib.rs
+++ b/crates/infer-backend-cuda/src/lib.rs
@@ -9,6 +9,7 @@ pub mod error;
 pub mod ffi;
 mod nccl;
 mod pool;
+mod timing;
 // Raw kernel launch wrappers are an implementation detail. Keeping this module
 // private prevents external callers from manufacturing invalid CUDA streams or
 // device pointers; the safe backend traits below are the supported API.
@@ -126,6 +127,10 @@ impl infer_core::exec::ExecScope for CudaScope {
 
     fn workspace(&self) -> &infer_core::exec::Workspace<Self::Device> {
         &self.workspace
+    }
+
+    fn create_timer(&self) -> OpResult<Option<Box<dyn infer_core::exec::ScopeTimer>>> {
+        Ok(Some(Box::new(timing::CudaTimer::new(self.device.clone())?)))
     }
 
     fn supports_graphs(&self) -> bool {

--- a/crates/infer-backend-cuda/src/lib.rs
+++ b/crates/infer-backend-cuda/src/lib.rs
@@ -595,6 +595,19 @@ impl infer_core::ports::MathOps for Cuda {
         })
     }
 
+    fn concat_cols<T: Dtype>(
+        scope: &<Self as infer_core::exec::ExecDevice>::Scope,
+        a: &Tensor<T, Self>,
+        b: &Tensor<T, Self>,
+        dst: &mut Tensor<T, Self>,
+    ) -> OpResult<()> {
+        let _guard = infer_core::exec::ExecScope::enter(scope);
+        require_scope_tensor(scope, a, "concat_cols a")?;
+        require_scope_tensor(scope, b, "concat_cols b")?;
+        require_scope_tensor(scope, dst, "concat_cols dst")?;
+        kernels::concat_seq::concat_cols_into(scope_stream(scope), a, b, dst)
+    }
+
     fn concat_seq<T: Dtype>(
         scope: &<Self as infer_core::exec::ExecDevice>::Scope,
         a: &Tensor<T, Self>,
@@ -1646,6 +1659,13 @@ impl CoreOps for Cuda {
                 dst_cols as i32,
             )
         })
+    }
+    fn concat_cols<T: Dtype>(
+        a: &Tensor<T, Self>,
+        b: &Tensor<T, Self>,
+        dst: &mut Tensor<T, Self>,
+    ) -> OpResult<()> {
+        kernels::concat_seq::concat_cols_into(a.device().config.stream, a, b, dst)
     }
     fn concat_seq<T: Dtype>(
         a: &Tensor<T, Self>,

--- a/crates/infer-backend-cuda/src/lib.rs
+++ b/crates/infer-backend-cuda/src/lib.rs
@@ -255,6 +255,36 @@ pub(crate) fn require_scope_tensor<T: Dtype>(
 }
 
 impl infer_core::ports::MathOps for Cuda {
+    fn copy_tensor<T: Dtype>(
+        scope: &Self::Scope,
+        src: &Tensor<T, Self>,
+        dst: &mut Tensor<T, Self>,
+    ) -> OpResult<()> {
+        if src.shape() != dst.shape()
+            || !src.is_contiguous()
+            || !dst.is_contiguous()
+            || src.device().device_id != scope.device.device_id
+            || dst.device().device_id != scope.device.device_id
+        {
+            return Err(OpError::Shape(
+                "copy_tensor shape/layout/device mismatch".into(),
+            ));
+        }
+        let bytes = src.numel() * T::SIZE_BYTES;
+        let s = src.data_ptr() as usize;
+        let d = dst.data_ptr() as usize;
+        if bytes == 0 || s == d {
+            return Ok(());
+        }
+        if s < d + bytes && d < s + bytes {
+            return Err(OpError::Shape(
+                "copy_tensor requires disjoint storage".into(),
+            ));
+        }
+        let _guard = infer_core::exec::ExecScope::enter(scope);
+        kernels::cast_dtype::cast_dtype(scope_stream(scope), src, dst)
+    }
+
     fn add<T: Dtype>(
         scope: &<Self as infer_core::exec::ExecDevice>::Scope,
         a: &Tensor<T, Self>,

--- a/crates/infer-backend-cuda/src/timing.rs
+++ b/crates/infer-backend-cuda/src/timing.rs
@@ -1,0 +1,78 @@
+//! Persistent event pairs for optional, nonblocking compute-stream sampling.
+use crate::error::cuda_check;
+use crate::{Cuda, CudaScope, ffi};
+use infer_core::exec::{ExecScope, ScopeTimer};
+use infer_core::ports::OpResult;
+
+pub(crate) struct CudaTimer {
+    // Keeps the stream/device alive until both events have been destroyed.
+    scope: CudaScope,
+    start: ffi::cudaEvent_t,
+    stop: ffi::cudaEvent_t,
+}
+// All event use is serialized through &mut self; CUDA handles may move threads.
+unsafe impl Send for CudaTimer {}
+impl CudaTimer {
+    pub(crate) fn new(device: Cuda) -> OpResult<Self> {
+        let scope = CudaScope::new(device);
+        let mut timer = Self {
+            scope,
+            start: std::ptr::null_mut(),
+            stop: std::ptr::null_mut(),
+        };
+        {
+            let _guard = timer.scope.enter();
+            unsafe {
+                cuda_check!(ffi::cudaEventCreate(&mut timer.start));
+                cuda_check!(ffi::cudaEventCreate(&mut timer.stop));
+            }
+        }
+        Ok(timer)
+    }
+}
+impl ScopeTimer for CudaTimer {
+    fn start(&mut self) -> OpResult<()> {
+        let _guard = self.scope.enter();
+        unsafe {
+            cuda_check!(ffi::cudaEventRecord(self.start, self.scope.stream().0));
+        }
+        Ok(())
+    }
+    fn stop(&mut self) -> OpResult<()> {
+        let _guard = self.scope.enter();
+        unsafe {
+            cuda_check!(ffi::cudaEventRecord(self.stop, self.scope.stream().0));
+        }
+        Ok(())
+    }
+    fn elapsed_ms(&mut self) -> OpResult<Option<f32>> {
+        let _guard = self.scope.enter();
+        let status = unsafe { ffi::cudaEventQuery(self.stop) };
+        if status == ffi::cudaError_cudaErrorNotReady {
+            return Ok(None);
+        }
+        cuda_check!(status);
+        let mut elapsed = 0.0;
+        unsafe {
+            cuda_check!(ffi::cudaEventElapsedTime(
+                &mut elapsed,
+                self.start,
+                self.stop
+            ));
+        }
+        Ok(Some(elapsed))
+    }
+}
+impl Drop for CudaTimer {
+    fn drop(&mut self) {
+        let _guard = self.scope.enter();
+        unsafe {
+            if !self.start.is_null() {
+                ffi::cudaEventDestroy(self.start);
+            }
+            if !self.stop.is_null() {
+                ffi::cudaEventDestroy(self.stop);
+            }
+        }
+    }
+}

--- a/crates/infer-backend-cuda/tests/graph_memory.rs
+++ b/crates/infer-backend-cuda/tests/graph_memory.rs
@@ -319,3 +319,29 @@ fn low_level_capture_without_an_arena_rejects_dynamic_allocation_and_recovers() 
         .expect("end capture with an arena");
     assert_replay(&scope, 1, &output, &[21, 22, 23, 24]);
 }
+
+#[test]
+#[ignore = "requires a CUDA GPU"]
+fn scoped_copy_is_capture_safe_and_rejects_partial_overlap() {
+    use infer_core::ports::MathOps;
+    let scope = scope();
+    let mut source = tensor(&scope, &[1, 2, 3, 4]);
+    let mut output = tensor(&scope, &[0, 0, 0, 0]);
+    let same = source.clone();
+    Cuda::copy_tensor(&scope, &same, &mut source).unwrap();
+    assert!(
+        Cuda::copy_tensor(
+            &scope,
+            &source.narrow(0, 0, 3).unwrap(),
+            &mut source.narrow(0, 1, 3).unwrap(),
+        )
+        .is_err()
+    );
+    scope.synchronize().unwrap();
+    scope.graph_capture_begin().unwrap();
+    Cuda::copy_tensor(&scope, &source, &mut output).unwrap();
+    scope.graph_capture_end(13).unwrap();
+    assert_replay(&scope, 13, &output, &[1, 2, 3, 4]);
+    source.upload_from_host(&[9, 8, 7, 6]).unwrap();
+    assert_replay(&scope, 13, &output, &[9, 8, 7, 6]);
+}

--- a/crates/infer-backend-cuda/tests/graph_memory.rs
+++ b/crates/infer-backend-cuda/tests/graph_memory.rs
@@ -345,3 +345,30 @@ fn scoped_copy_is_capture_safe_and_rejects_partial_overlap() {
     source.upload_from_host(&[9, 8, 7, 6]).unwrap();
     assert_replay(&scope, 13, &output, &[9, 8, 7, 6]);
 }
+
+#[test]
+#[ignore = "requires CUDA GPU"]
+fn scope_timing_supports_replay_and_keeps_stream_alive() {
+    let scope = scope();
+    let input = tensor(&scope, &[7, 8, 9]);
+    let mut output = tensor(&scope, &[0, 0, 0]);
+    let mut timer = scope.create_timer().unwrap().expect("CUDA timer");
+    scope.graph_capture_begin().unwrap();
+    <Cuda as infer_core::ports::MathOps>::copy_tensor(&scope, &input, &mut output).unwrap();
+    scope.graph_capture_end(7171).unwrap();
+    timer.start().unwrap();
+    scope.graph_launch(7171).unwrap();
+    timer.stop().unwrap();
+    // Polling may yield None while work is pending; only the test synchronizes.
+    let _ = timer.elapsed_ms().unwrap();
+    scope.synchronize().unwrap();
+    let ms = timer.elapsed_ms().unwrap().expect("completed event");
+    assert!(ms.is_finite() && ms >= 0.0);
+    assert_eq!(output.to_host_vec().unwrap(), vec![7, 8, 9]);
+    drop(input);
+    drop(output);
+    drop(scope);
+    timer.start().unwrap();
+    timer.stop().unwrap();
+    // Timer owns its CUDA context through asynchronous destruction.
+}

--- a/crates/infer-core/src/exec.rs
+++ b/crates/infer-core/src/exec.rs
@@ -35,6 +35,14 @@ pub trait ExecDevice: MemoryPort {
 
 pub trait ExecHostDevice: ExecDevice {}
 
+/// Optional compute-stream timing pair. Recording and polling must never wait
+/// for GPU completion. Owners allocate pairs before serving and serialize use.
+pub trait ScopeTimer: Send {
+    fn start(&mut self) -> OpResult<()>;
+    fn stop(&mut self) -> OpResult<()>;
+    fn elapsed_ms(&mut self) -> OpResult<Option<f32>>;
+}
+
 pub trait ExecScope: Send + Sync + Sized + 'static {
     type Device: ExecDevice<Scope = Self>;
     type Stream: Stream;
@@ -46,6 +54,9 @@ pub trait ExecScope: Send + Sync + Sized + 'static {
     fn topology(&self) -> TopologyShape;
     fn quant_tier(&self) -> QuantTier;
     fn workspace(&self) -> &Workspace<Self::Device>;
+    fn create_timer(&self) -> OpResult<Option<Box<dyn ScopeTimer>>> {
+        Ok(None)
+    }
     fn supports_graphs(&self) -> bool {
         false
     }

--- a/crates/infer-core/src/ports.rs
+++ b/crates/infer-core/src/ports.rs
@@ -31,5 +31,5 @@ pub use op_ports::{CoreOps, DiffusionOps, OpBackend};
 pub use pipeline_ops::{
     CompactExtendControlArgs, DecodePipelineOps, MergeCompactDecodeArgs, MergeCompactMixedArgs,
 };
-pub use sampler::{AcceptReject, SampleBatch, SampledToken, Sampler, SamplingParams};
+pub use sampler::{SampleBatch, SampledToken, Sampler, SamplingParams};
 pub use vocab_ops::VocabOps;

--- a/crates/infer-core/src/ports/math_ops.rs
+++ b/crates/infer-core/src/ports/math_ops.rs
@@ -159,6 +159,14 @@ pub trait MathOps: Device {
         dst_cols: usize,
     ) -> OpResult<()>;
 
+    /// Concatenate contiguous matrices by columns into disjoint output storage.
+    fn concat_cols<T: Dtype>(
+        scope: &Self::Scope,
+        a: &Tensor<T, Self>,
+        b: &Tensor<T, Self>,
+        dst: &mut Tensor<T, Self>,
+    ) -> OpResult<()>;
+
     fn concat_seq<T: Dtype>(
         scope: &Self::Scope,
         a: &Tensor<T, Self>,
@@ -447,6 +455,16 @@ macro_rules! impl_math_ops_via_core_ops {
             ) -> $crate::ports::OpResult<()> {
                 let _guard = infer_core::exec::ExecScope::enter(scope);
                 <Self as $crate::ports::CoreOps>::concat_seq(a, b, dst)
+            }
+
+            fn concat_cols<T: infer_core::dtype::Dtype>(
+                scope: &<Self as infer_core::exec::ExecDevice>::Scope,
+                a: &infer_core::tensor::Tensor<T, Self>,
+                b: &infer_core::tensor::Tensor<T, Self>,
+                dst: &mut infer_core::tensor::Tensor<T, Self>,
+            ) -> $crate::ports::OpResult<()> {
+                let _guard = infer_core::exec::ExecScope::enter(scope);
+                <Self as $crate::ports::CoreOps>::concat_cols(a, b, dst)
             }
 
             fn cast<S: infer_core::dtype::Dtype, T: infer_core::dtype::Dtype>(

--- a/crates/infer-core/src/ports/math_ops.rs
+++ b/crates/infer-core/src/ports/math_ops.rs
@@ -11,6 +11,16 @@ use infer_core::tensor::Tensor;
 use infer_core::types::{Shape, Strides};
 
 pub trait MathOps: Device {
+    /// Stream-ordered copy between disjoint, contiguous tensors. As with other
+    /// operators, callers keep both storages alive until execution completes.
+    fn copy_tensor<T: Dtype>(
+        _scope: &Self::Scope,
+        src: &Tensor<T, Self>,
+        dst: &mut Tensor<T, Self>,
+    ) -> OpResult<()> {
+        dst.copy_from(src)
+    }
+
     fn alloc_tensor<T: Dtype>(shape: Shape, device: &Self) -> OpResult<Tensor<T, Self>> {
         Tensor::<T, Self>::zeros(shape, device)
     }

--- a/crates/infer-core/src/ports/op_ports.rs
+++ b/crates/infer-core/src/ports/op_ports.rs
@@ -149,6 +149,13 @@ pub trait CoreOps: MemoryPort {
         dst_cols: usize,
     ) -> OpResult<()>;
 
+    /// Concatenate contiguous matrices by columns into disjoint output storage.
+    fn concat_cols<T: Dtype>(
+        a: &Tensor<T, Self>,
+        b: &Tensor<T, Self>,
+        dst: &mut Tensor<T, Self>,
+    ) -> OpResult<()>;
+
     /// Concat two `[*, D]` tensors along dim 0 into a pre-allocated dst.
     fn concat_seq<T: Dtype>(
         a: &Tensor<T, Self>,

--- a/crates/infer-core/src/ports/sampler.rs
+++ b/crates/infer-core/src/ports/sampler.rs
@@ -51,12 +51,6 @@ pub struct SampleBatch {
     pub tokens: Vec<SampledToken>,
 }
 
-#[derive(Debug, Clone)]
-pub struct AcceptReject {
-    pub accepted_count: Vec<u32>,
-    pub bonus_token: Vec<SampledToken>,
-}
-
 pub trait Sampler<T: Dtype, D: LlmBackend>: Send + Sync {
     fn sample(
         &self,
@@ -68,35 +62,6 @@ pub trait Sampler<T: Dtype, D: LlmBackend>: Send + Sync {
         Err(OpError::unsupported(
             logits.device().name(),
             "sampler.sample",
-        ))
-    }
-
-    fn probs(
-        &self,
-        logits: &Tensor<T, D>,
-        params: &[SamplingParams],
-        out: &mut Tensor<f32, D>,
-        ctx: &StepCtx<'_, D>,
-    ) -> OpResult<()> {
-        let _ = (params, out, ctx);
-        Err(OpError::unsupported(
-            logits.device().name(),
-            "sampler.probs",
-        ))
-    }
-
-    fn verify(
-        &self,
-        target_logits: &Tensor<T, D>,
-        draft_tokens: &[i32],
-        draft_probs: &Tensor<f32, D>,
-        params: &[SamplingParams],
-        ctx: &StepCtx<'_, D>,
-    ) -> OpResult<AcceptReject> {
-        let _ = (draft_tokens, draft_probs, params, ctx);
-        Err(OpError::unsupported(
-            target_logits.device().name(),
-            "sampler.verify",
         ))
     }
 }

--- a/crates/infer-protocol/src/config.rs
+++ b/crates/infer-protocol/src/config.rs
@@ -189,6 +189,11 @@ pub struct RustInferConfig {
     #[serde(default = "default_capture_sizes")]
     pub capture_sizes: Vec<usize>,
 
+    /// Qwen3.5 text MTP serving. Zero disables speculation. The first serving
+    /// implementation requires TP1, one active sequence, and no prefix caching.
+    #[serde(default)]
+    pub mtp_num_draft_tokens: usize,
+
     /// CUDA scratch-memory plan. Read only from this shared launch config.
     #[serde(default)]
     pub cuda_memory: CudaMemoryConfig,
@@ -299,6 +304,14 @@ impl RustInferConfig {
         }
         if self.max_batch_seqs == 0 {
             return Err("`max_batch_seqs` must be > 0".into());
+        }
+        if self.mtp_num_draft_tokens > 0
+            && (self.tensor_parallel_size != 1
+                || self.max_batch_seqs != 1
+                || self.enable_prefix_caching
+                || self.mtp_num_draft_tokens >= self.max_batch_tokens)
+        {
+            return Err("MTP requires tensor_parallel_size=1, max_batch_seqs=1, enable_prefix_caching=false, and draft tokens < max_batch_tokens".into());
         }
         if self.paged_block_size == 0 {
             return Err("`paged_block_size` must be > 0".into());
@@ -539,6 +552,22 @@ mod model_type_tests {
 #[cfg(test)]
 mod launch_config_tests {
     use super::RustInferConfig;
+
+    #[test]
+    fn mtp_is_opt_in_and_rejects_incompatible_serving_limits() {
+        let mut cfg: RustInferConfig = toml::from_str("model='/tmp/model'").unwrap();
+        assert_eq!(cfg.mtp_num_draft_tokens, 0);
+        cfg.mtp_num_draft_tokens = 3;
+        assert!(cfg.validate().is_err());
+        cfg.max_batch_seqs = 1;
+        cfg.enable_prefix_caching = false;
+        cfg.validate().unwrap();
+        cfg.tensor_parallel_size = 2;
+        assert!(cfg.validate().is_err());
+        cfg.tensor_parallel_size = 1;
+        cfg.max_batch_tokens = 3;
+        assert!(cfg.validate().is_err());
+    }
 
     #[test]
     fn tensor_parallel_size_defaults_to_one_and_accepts_explicit_value() {

--- a/crates/infer-scheduler/src/application/engine_tests.rs
+++ b/crates/infer-scheduler/src/application/engine_tests.rs
@@ -60,7 +60,8 @@ struct MockFrontend;
 #[async_trait]
 impl FrontendTransport for MockFrontend {
     async fn recv_event(&mut self) -> Result<FrontendEvent> {
-        Err(crate::error::SchedulerError::Shutdown)
+        // An idle frontend must not race control-plane events with shutdown.
+        std::future::pending().await
     }
 
     async fn send_response(
@@ -769,7 +770,12 @@ async fn control_plane_closure_is_not_hidden_by_idle_readiness_ticks() {
     let (mut engine, _, event_tx, _cmd_rx) = make_engine();
     drop(event_tx);
     let (_decoded_tx, mut decoded_rx) = tokio::sync::mpsc::unbounded_channel();
-    let event = engine.poll_next_event(&mut decoded_rx).await;
+    let event = tokio::time::timeout(
+        std::time::Duration::from_secs(2),
+        engine.poll_next_event(&mut decoded_rx),
+    )
+    .await
+    .expect("closed control plane must wake the idle scheduler");
     assert!(matches!(event, SchedulerEvent::WorkerShutdown));
 }
 

--- a/crates/infer-scheduler/src/application/output.rs
+++ b/crates/infer-scheduler/src/application/output.rs
@@ -120,6 +120,63 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn speculative_burst_stops_before_later_tokens_are_appended_or_streamed() {
+        use crate::domain::inference_session::table::RequestTable;
+        use crate::infrastructure::metrics::MetricsRecorder;
+        use infer_protocol::worker_to_scheduler_data::{GeneratedToken, StepOutput};
+        for stream in [false, true] {
+            let mut meta = meta_for_test(stream, vec![1, 2, 3, 4]);
+            Arc::get_mut(&mut meta).unwrap().stop_sequences = vec![vec![7, 8]];
+            let request_id = meta.id;
+            let mut table = RequestTable::new();
+            table.insert_new(meta, RequestHandle::noop()).unwrap();
+            let queued = table.take_waiting(&request_id).unwrap();
+            table
+                .commit_prefill_start(
+                    queued,
+                    crate::infrastructure::kv_cache::traits::PrefixMatch::none(),
+                    4,
+                )
+                .unwrap();
+            table.ack_prefill(SequenceId(1)).unwrap();
+            let mut frontend = CapturingFrontend::default();
+            let out = StepOutput {
+                prefill_done: vec![],
+                assigned_indices: vec![],
+                tokens: [5, 7, 8, 9]
+                    .into_iter()
+                    .map(|token_id| GeneratedToken {
+                        sequence_id: 1,
+                        token_id,
+                        finished: token_id == 9,
+                    })
+                    .collect(),
+            };
+            let done = crate::application::output_fns::process_llm_step_decoded(
+                &mut table,
+                &mut frontend,
+                &MetricsRecorder::new(false),
+                &out,
+            )
+            .await
+            .unwrap();
+            assert_eq!(done.len(), 1);
+            assert!(done[0].stop_sequence_finished);
+            assert_eq!(table.decoding_len(), 0);
+            if !stream {
+                let responses = frontend.responses.lock().unwrap();
+                assert_eq!(responses.len(), 1);
+                assert_eq!(responses[0].output_token_ids, [5]);
+            }
+            let chunks = frontend.chunks.lock().unwrap();
+            assert_eq!(
+                chunks.iter().filter_map(|c| c.token_id).collect::<Vec<_>>(),
+                if stream { vec![5] } else { vec![] }
+            );
+        }
+    }
+
+    #[tokio::test]
     async fn fail_prefilling_emits_error_response() {
         let mut frontend = CapturingFrontend::default();
         crate::application::output_fns::fail_prefilling_session(

--- a/crates/infer-scheduler/src/application/output_fns.rs
+++ b/crates/infer-scheduler/src/application/output_fns.rs
@@ -261,7 +261,14 @@ pub async fn process_llm_step_decoded(
     // 2. Process generated tokens.
     let mut finished_sequences: Vec<CompletedSequence> = Vec::new();
     let mut token_chunks: Vec<(ClientId, StreamChunk)> = Vec::new();
+    let mut stopped = std::collections::HashSet::new();
     for token in &output.tokens {
+        // A speculative burst can contain several tokens for one sequence.
+        // Stop strings are matched here; later tokens in that burst must not
+        // be appended or streamed after the first terminal token.
+        if stopped.contains(&token.sequence_id) {
+            continue;
+        }
         match sessions.append_generated_token(
             SequenceId(token.sequence_id),
             token.token_id,
@@ -283,6 +290,7 @@ pub async fn process_llm_step_decoded(
                     }
                 }
                 if outcome.finished {
+                    stopped.insert(token.sequence_id);
                     finished_sequences.push(CompletedSequence {
                         sequence_id: outcome.sequence_id,
                         worker_finished: outcome.worker_finished,

--- a/crates/infer-server/src/api/openai/chat.rs
+++ b/crates/infer-server/src/api/openai/chat.rs
@@ -30,6 +30,13 @@ pub async fn chat_completions(
 
     // 1. 校验请求
     validate_request(&req)?;
+    shared::validate_mtp_request(
+        state.config.mtp_num_draft_tokens,
+        req.temperature,
+        req.top_p,
+        req.top_k,
+        req.messages.iter().any(InputChatMessage::has_image),
+    )?;
     let response_model = state.model_info.model_id.clone();
 
     let mut image_permit = if req.messages.iter().any(InputChatMessage::has_image) {

--- a/crates/infer-server/src/api/openai/completion.rs
+++ b/crates/infer-server/src/api/openai/completion.rs
@@ -26,6 +26,13 @@ pub async fn completions(
 ) -> Result<Response, AppError> {
     // 1. 校验
     validate_request(&req, state.tokenizer.get_vocab_size(true))?;
+    shared::validate_mtp_request(
+        state.config.mtp_num_draft_tokens,
+        req.temperature,
+        req.top_p,
+        req.top_k,
+        false,
+    )?;
     let response_model = state.model_info.model_id.clone();
 
     // 2. 获取 input_ids（直接 tokenize prompt，不经过 chat template）

--- a/crates/infer-server/src/api/openai/shared.rs
+++ b/crates/infer-server/src/api/openai/shared.rs
@@ -15,6 +15,28 @@ use super::types::StopSequence;
 /// Bound CPU work independently of the larger image data-URL body limit.
 pub const MAX_TEXT_BYTES: usize = 1024 * 1024;
 
+pub fn validate_mtp_request(
+    draft_tokens: usize,
+    temperature: Option<f32>,
+    top_p: Option<f32>,
+    top_k: Option<i32>,
+    has_image: bool,
+) -> Result<(), AppError> {
+    if draft_tokens > 0 {
+        if has_image {
+            return Err(AppError::bad_request(
+                "MTP currently supports text input only",
+            ));
+        }
+        if temperature.unwrap_or(1.0) > 0.0 && top_k != Some(1) && top_p.unwrap_or(1.0) > 0.0 {
+            return Err(AppError::bad_request(
+                "MTP currently requires greedy sampling (temperature=0, top_k=1, or top_p=0)",
+            ));
+        }
+    }
+    Ok(())
+}
+
 pub fn validate_text_bytes(bytes: usize) -> Result<(), AppError> {
     if bytes > MAX_TEXT_BYTES {
         return Err(AppError::bad_request("request text exceeds 1 MiB"));
@@ -212,6 +234,16 @@ pub fn decode_completion(
 
 #[cfg(test)]
 mod tests {
+    #[test]
+    fn mtp_request_limits_do_not_change_ordinary_sampling() {
+        use super::validate_mtp_request;
+        assert!(validate_mtp_request(0, None, None, None, true).is_ok());
+        assert!(validate_mtp_request(3, Some(0.0), None, None, false).is_ok());
+        assert!(validate_mtp_request(3, None, None, Some(1), false).is_ok());
+        assert!(validate_mtp_request(3, None, Some(0.0), None, false).is_ok());
+        assert!(validate_mtp_request(3, None, None, None, false).is_err());
+        assert!(validate_mtp_request(3, Some(0.0), None, None, true).is_err());
+    }
     use super::*;
     use tokenizers::models::wordlevel::WordLevel;
     use tokenizers::pre_tokenizers::whitespace::Whitespace;

--- a/crates/infer-worker/src/application/decode_engine.rs
+++ b/crates/infer-worker/src/application/decode_engine.rs
@@ -642,16 +642,27 @@ impl DecodeEngine {
         let runtime_result = runner.finalize_decode_abc(p.batch);
         match runtime_result {
             Ok(compact) => {
-                let output = self.commit_results(
-                    active,
-                    kv_allocator,
-                    &p.order,
-                    p.new_indices,
-                    p.assigned,
-                    &compact,
-                    enable_prefix_caching,
-                    p.device_prepared,
-                )?;
+                let output = crate::application::execution::ExecutionPlan::eager(
+                    crate::application::execution::Phase::Commit,
+                    p.batch,
+                    p.batch,
+                    crate::application::execution::WorkspaceUse::Abc,
+                )
+                .execute(&runner.execution_metrics, |_| {
+                    self.commit_results(
+                        active,
+                        kv_allocator,
+                        &p.order,
+                        p.new_indices,
+                        p.assigned,
+                        &compact,
+                        enable_prefix_caching,
+                        p.device_prepared,
+                    )
+                })?;
+                runner
+                    .execution_metrics
+                    .committed(0, 0, output.tokens.len(), output.tokens.len());
                 // A now holds the surviving tokens compacted to the front in
                 // `rows` order (commit_results just set `rows` to the survivors).
                 self.prev_a_rows = self.rows.as_slice().to_vec();

--- a/crates/infer-worker/src/application/execution.rs
+++ b/crates/infer-worker/src/application/execution.rs
@@ -1,0 +1,517 @@
+//! Shared execution contracts and allocation-free phase accounting.
+//!
+//! Plans describe operations; BatchPlan still owns model-specific indexing.
+//! Host spans include existing waits; optional GPU spans use nonblocking events.
+//! No timer adds a device synchronization or changes buffer ownership.
+use crate::domain::ports::{OpError, OpResult};
+use infer_core::exec::{ExecScope, ScopeTimer};
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant};
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[repr(usize)]
+pub enum Phase {
+    Prefill,
+    Decode,
+    Mixed,
+    Draft,
+    Verify,
+    Snapshot,
+    Restore,
+    Replay,
+    CatchUp,
+    Readout,
+    Wait,
+    Commit,
+}
+const PHASES: [Phase; 12] = [
+    Phase::Prefill,
+    Phase::Decode,
+    Phase::Mixed,
+    Phase::Draft,
+    Phase::Verify,
+    Phase::Snapshot,
+    Phase::Restore,
+    Phase::Replay,
+    Phase::CatchUp,
+    Phase::Readout,
+    Phase::Wait,
+    Phase::Commit,
+];
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ExecutionMode {
+    Eager,
+    DecodeGraph { slot: usize },
+    PrefillGraph { tokens: usize },
+    MixedGraph { key: u64 },
+}
+
+/// References to existing allocations, never a request for new storage.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum WorkspaceUse {
+    /// Runtime owns staging, hidden and sample output until this call returns.
+    Runtime,
+    /// A/B/C remain borrowed until the matching decode finalize completes.
+    Abc,
+    /// Proposer owns token tape and ping-pong hidden; consumed before next draft.
+    Proposer,
+    /// Runtime borrows the proposer's tape for verification/replay synchronously.
+    BorrowedTape,
+    /// Persistent recurrent snapshot; overwritten by the next transaction.
+    Recurrent,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct ExecutionPlan {
+    pub phase: Phase,
+    pub mode: ExecutionMode,
+    pub batch: usize,
+    pub tokens: usize,
+    pub workspace: WorkspaceUse,
+}
+
+impl ExecutionPlan {
+    pub fn eager(phase: Phase, batch: usize, tokens: usize, workspace: WorkspaceUse) -> Self {
+        Self {
+            phase,
+            mode: ExecutionMode::Eager,
+            batch,
+            tokens,
+            workspace,
+        }
+    }
+
+    pub fn validate(&self) -> OpResult<()> {
+        let valid = match self.mode {
+            ExecutionMode::Eager => true,
+            ExecutionMode::DecodeGraph { slot } => {
+                self.phase == Phase::Decode
+                    && self.tokens == self.batch
+                    && slot >= self.batch
+                    && slot > 0
+            }
+            ExecutionMode::MixedGraph { .. } => self.phase == Phase::Mixed && self.tokens > 0,
+            ExecutionMode::PrefillGraph { tokens } => {
+                self.phase == Phase::Prefill && tokens == self.tokens && tokens > 0
+            }
+        };
+        let workspace_valid = match self.workspace {
+            WorkspaceUse::Runtime => true,
+            WorkspaceUse::Abc => matches!(
+                self.phase,
+                Phase::Decode | Phase::Mixed | Phase::Wait | Phase::Commit
+            ),
+            WorkspaceUse::Proposer => {
+                matches!(self.phase, Phase::Draft | Phase::CatchUp | Phase::Wait)
+            }
+            WorkspaceUse::BorrowedTape => {
+                matches!(self.phase, Phase::Verify | Phase::Replay | Phase::Wait)
+            }
+            WorkspaceUse::Recurrent => matches!(self.phase, Phase::Snapshot | Phase::Restore),
+        };
+        if (self.batch == 0 && self.phase != Phase::Wait) || !valid || !workspace_valid {
+            return Err(OpError::Shape("invalid execution phase/graph shape".into()));
+        }
+        Ok(())
+    }
+
+    /// One entry point for ordinary and speculative operations. The closure
+    /// receives the validated plan so graph dispatch uses the recorded decision.
+    pub fn execute<R>(
+        self,
+        metrics: &ExecutionMetrics,
+        op: impl FnOnce(Self) -> OpResult<R>,
+    ) -> OpResult<R> {
+        self.validate()?;
+        let started = metrics.0.as_ref().map(|_| Instant::now());
+        let gpu_sample = metrics.begin_gpu(self.phase);
+        let result = op(self);
+        if gpu_sample {
+            metrics.end_gpu(self.phase, result.is_ok());
+        }
+        if let Some(started) = started {
+            metrics.record(self, started.elapsed(), result.is_ok());
+        }
+        result
+    }
+}
+
+#[derive(Clone, Copy, Debug, Default)]
+pub struct PhaseStats {
+    pub calls: u64,
+    pub failures: u64,
+    pub tokens: u64,
+    pub graph_calls: u64,
+    pub host_ns: u64,
+    pub max_host_ns: u64,
+    pub gpu_samples: u64,
+    pub gpu_total_ms: f64,
+}
+
+#[derive(Clone, Copy, Debug, Default)]
+pub struct TokenStats {
+    pub rounds: u64,
+    pub proposed: u64,
+    pub accepted: u64,
+    pub emitted: u64,
+    pub materialized: u64,
+}
+
+struct TimingSlot {
+    timer: Option<Box<dyn ScopeTimer>>,
+    pending: bool,
+    active: bool,
+    success: bool,
+    calls: u64,
+}
+struct GpuTimings {
+    sample_every: u64,
+    slots: [TimingSlot; PHASES.len()],
+}
+struct MetricsInner {
+    owner: &'static str,
+    report_every: u64,
+    phases: Mutex<[PhaseStats; PHASES.len()]>,
+    tokens: Mutex<TokenStats>,
+    gpu: Mutex<Option<GpuTimings>>,
+}
+
+/// Disabled by default: no clock reads, locks or per-step allocations.
+/// Enabled storage is fixed-size and allocated once with its owner at startup.
+#[derive(Clone, Default)]
+pub struct ExecutionMetrics(Option<Arc<MetricsInner>>);
+
+impl ExecutionMetrics {
+    pub fn from_env(owner: &'static str) -> Self {
+        let every = std::env::var("RUSTINFER_EXECUTION_STATS_EVERY")
+            .ok()
+            .and_then(|s| s.parse::<u64>().ok())
+            .unwrap_or(0);
+        Self::new(owner, every)
+    }
+
+    pub fn new(owner: &'static str, report_every: u64) -> Self {
+        Self((report_every > 0).then(|| {
+            Arc::new(MetricsInner {
+                owner,
+                report_every,
+                phases: Mutex::new([PhaseStats::default(); PHASES.len()]),
+                tokens: Mutex::new(TokenStats::default()),
+                gpu: Mutex::new(None),
+            })
+        }))
+    }
+
+    /// Reserve event pairs before graph priming/serving. Host-only backends
+    /// keep returning None. Allocation errors fail startup, not a live request.
+    pub fn prepare_gpu<S: ExecScope>(&self, scope: &S) -> OpResult<()> {
+        let Some(m) = &self.0 else {
+            return Ok(());
+        };
+        let every = std::env::var("RUSTINFER_EXECUTION_GPU_SAMPLE_EVERY")
+            .ok()
+            .and_then(|s| s.parse::<u64>().ok())
+            .unwrap_or(0);
+        if every == 0 {
+            return Ok(());
+        }
+        let mut storage = m.gpu.lock().unwrap_or_else(|e| e.into_inner());
+        if storage.is_some() {
+            return Ok(());
+        }
+        let mut slots = std::array::from_fn(|_| TimingSlot {
+            timer: None,
+            pending: false,
+            active: false,
+            success: false,
+            calls: 0,
+        });
+        for phase in PHASES {
+            // Host waits and commits have no compute region of their own.
+            if !matches!(phase, Phase::Wait | Phase::Commit) {
+                slots[phase as usize].timer = scope.create_timer()?;
+            }
+        }
+        *storage = Some(GpuTimings {
+            sample_every: every,
+            slots,
+        });
+        Ok(())
+    }
+
+    fn begin_gpu(&self, phase: Phase) -> bool {
+        let Some(m) = &self.0 else {
+            return false;
+        };
+        let mut storage = m.gpu.lock().unwrap_or_else(|e| e.into_inner());
+        let Some(gpu) = storage.as_mut() else {
+            return false;
+        };
+        let slot = &mut gpu.slots[phase as usize];
+        if slot.active {
+            return false;
+        }
+        let Some(timer) = slot.timer.as_mut() else {
+            return false;
+        };
+        let result = (|| -> OpResult<bool> {
+            if slot.pending {
+                match timer.elapsed_ms()? {
+                    None => return Ok(false), // Never overwrite an unfinished pair.
+                    Some(ms) => {
+                        slot.pending = false;
+                        if slot.success {
+                            let mut phases = m.phases.lock().unwrap_or_else(|e| e.into_inner());
+                            let s = &mut phases[phase as usize];
+                            s.gpu_samples = s.gpu_samples.saturating_add(1);
+                            s.gpu_total_ms += ms as f64;
+                        }
+                    }
+                }
+            }
+            slot.calls = slot.calls.wrapping_add(1);
+            if (slot.calls - 1).is_multiple_of(gpu.sample_every) {
+                timer.start()?;
+                slot.active = true;
+                return Ok(true);
+            }
+            Ok(false)
+        })();
+        match result {
+            Ok(active) => active,
+            Err(error) => {
+                tracing::warn!(target: "execution_stats", ?phase, %error, "GPU timer disabled");
+                slot.timer = None;
+                false
+            }
+        }
+    }
+
+    fn end_gpu(&self, phase: Phase, success: bool) {
+        let Some(m) = &self.0 else {
+            return;
+        };
+        let mut storage = m.gpu.lock().unwrap_or_else(|e| e.into_inner());
+        let Some(gpu) = storage.as_mut() else {
+            return;
+        };
+        let slot = &mut gpu.slots[phase as usize];
+        slot.active = false;
+        if let Some(timer) = slot.timer.as_mut() {
+            match timer.stop() {
+                Ok(()) => {
+                    slot.pending = true;
+                    slot.success = success;
+                }
+                Err(error) => {
+                    tracing::warn!(target: "execution_stats", ?phase, %error, "GPU timer disabled");
+                    slot.timer = None;
+                }
+            }
+        }
+    }
+
+    pub fn snapshot(&self, phase: Phase) -> PhaseStats {
+        self.0.as_ref().map_or(PhaseStats::default(), |m| {
+            m.phases.lock().unwrap_or_else(|e| e.into_inner())[phase as usize]
+        })
+    }
+
+    pub fn token_snapshot(&self) -> TokenStats {
+        self.0.as_ref().map_or(TokenStats::default(), |m| {
+            *m.tokens.lock().unwrap_or_else(|e| e.into_inner())
+        })
+    }
+
+    fn record(&self, plan: ExecutionPlan, elapsed: Duration, success: bool) {
+        let Some(m) = &self.0 else {
+            return;
+        };
+        let stats = {
+            let mut phases = m.phases.lock().unwrap_or_else(|e| e.into_inner());
+            let s = &mut phases[plan.phase as usize];
+            let ns = elapsed.as_nanos().min(u64::MAX as u128) as u64;
+            s.calls = s.calls.saturating_add(1);
+            s.failures = s.failures.saturating_add(u64::from(!success));
+            if success {
+                s.tokens = s.tokens.saturating_add(plan.tokens as u64);
+            }
+            s.graph_calls = s
+                .graph_calls
+                .saturating_add(u64::from(plan.mode != ExecutionMode::Eager));
+            s.host_ns = s.host_ns.saturating_add(ns);
+            s.max_host_ns = s.max_host_ns.max(ns);
+            *s
+        };
+        tracing::debug!(target: "execution_stats", owner = m.owner, phase = ?plan.phase,
+            mode = ?plan.mode, workspace = ?plan.workspace, batch = plan.batch,
+            tokens = plan.tokens, success, host_ms = elapsed.as_secs_f64() * 1e3,
+            "execution phase");
+        if stats.calls.is_multiple_of(m.report_every) {
+            log_phase(m.owner, plan.phase, stats);
+        }
+    }
+
+    /// Call only after a successful state/output commit. Accepted drafts and
+    /// emitted tokens are separate: the bonus token is not an accepted draft.
+    pub fn committed(&self, proposed: usize, accepted: usize, emitted: usize, materialized: usize) {
+        let Some(m) = &self.0 else {
+            return;
+        };
+        let s = {
+            let mut s = m.tokens.lock().unwrap_or_else(|e| e.into_inner());
+            s.rounds = s.rounds.saturating_add(1);
+            s.proposed = s.proposed.saturating_add(proposed as u64);
+            s.accepted = s.accepted.saturating_add(accepted as u64);
+            s.emitted = s.emitted.saturating_add(emitted as u64);
+            s.materialized = s.materialized.saturating_add(materialized as u64);
+            *s
+        };
+        if s.rounds.is_multiple_of(m.report_every) {
+            log_tokens(m.owner, s);
+        }
+    }
+}
+
+fn log_phase(owner: &str, phase: Phase, s: PhaseStats) {
+    tracing::info!(target: "execution_stats", owner, phase = ?phase, calls = s.calls,
+        failures = s.failures, tokens = s.tokens, graph_calls = s.graph_calls,
+        host_total_ms = s.host_ns as f64 / 1e6,
+        host_mean_ms = s.host_ns as f64 / s.calls.max(1) as f64 / 1e6,
+        host_max_ms = s.max_host_ns as f64 / 1e6,
+        gpu_samples = s.gpu_samples, gpu_total_ms = s.gpu_total_ms,
+        gpu_mean_ms = (s.gpu_samples > 0).then(|| s.gpu_total_ms / s.gpu_samples as f64), "execution summary");
+}
+fn log_tokens(owner: &str, s: TokenStats) {
+    tracing::info!(target: "execution_stats", owner, rounds = s.rounds,
+        proposed = s.proposed, accepted = s.accepted, emitted = s.emitted,
+        materialized = s.materialized,
+        acceptance_rate = (s.proposed > 0).then(|| s.accepted as f64 / s.proposed as f64),
+        "execution tokens");
+}
+impl Drop for MetricsInner {
+    fn drop(&mut self) {
+        let phases = self.phases.get_mut().unwrap_or_else(|e| e.into_inner());
+        for (phase, stats) in PHASES.into_iter().zip(phases.iter()) {
+            if stats.calls > 0 {
+                log_phase(self.owner, phase, *stats);
+            }
+        }
+        let tokens = *self.tokens.get_mut().unwrap_or_else(|e| e.into_inner());
+        if tokens.rounds > 0 {
+            log_tokens(self.owner, tokens);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    #[test]
+    fn unfinished_gpu_samples_are_not_overwritten() {
+        use std::sync::atomic::{AtomicUsize, Ordering};
+        struct Timer {
+            starts: Arc<AtomicUsize>,
+            polls: usize,
+        }
+        impl ScopeTimer for Timer {
+            fn start(&mut self) -> OpResult<()> {
+                self.starts.fetch_add(1, Ordering::Relaxed);
+                Ok(())
+            }
+            fn stop(&mut self) -> OpResult<()> {
+                Ok(())
+            }
+            fn elapsed_ms(&mut self) -> OpResult<Option<f32>> {
+                self.polls += 1;
+                Ok((self.polls >= 3).then_some(2.5))
+            }
+        }
+        let starts = Arc::new(AtomicUsize::new(0));
+        let m = ExecutionMetrics::new("test", 100);
+        let mut slots = std::array::from_fn(|_| TimingSlot {
+            timer: None,
+            pending: false,
+            active: false,
+            success: false,
+            calls: 0,
+        });
+        slots[Phase::Decode as usize].timer = Some(Box::new(Timer {
+            starts: starts.clone(),
+            polls: 0,
+        }));
+        *m.0.as_ref().unwrap().gpu.lock().unwrap() = Some(GpuTimings {
+            sample_every: 1,
+            slots,
+        });
+        let p = ExecutionPlan::eager(Phase::Decode, 1, 1, WorkspaceUse::Abc);
+        for _ in 0..4 {
+            p.execute(&m, |_| Ok(())).unwrap();
+        }
+        assert_eq!(starts.load(Ordering::Relaxed), 2);
+        let s = m.snapshot(Phase::Decode);
+        assert_eq!(s.calls, 4);
+        assert_eq!(s.gpu_samples, 1);
+        assert_eq!(s.gpu_total_ms, 2.5);
+    }
+
+    #[test]
+    fn graph_contract_rejects_verification_and_undersized_slots() {
+        let p = ExecutionPlan {
+            mode: ExecutionMode::DecodeGraph { slot: 2 },
+            ..ExecutionPlan::eager(Phase::Verify, 1, 2, WorkspaceUse::BorrowedTape)
+        };
+        assert!(
+            p.execute(&ExecutionMetrics::default(), |_| -> OpResult<()> {
+                panic!("must not execute")
+            })
+            .is_err()
+        );
+        let p = ExecutionPlan {
+            phase: Phase::Decode,
+            workspace: WorkspaceUse::Abc,
+            batch: 3,
+            tokens: 3,
+            ..p
+        };
+        assert!(p.validate().is_err());
+        assert!(
+            ExecutionPlan::eager(Phase::Decode, 1, 1, WorkspaceUse::BorrowedTape)
+                .validate()
+                .is_err()
+        );
+        assert!(
+            ExecutionPlan {
+                batch: 1,
+                tokens: 1,
+                ..p
+            }
+            .validate()
+            .is_ok()
+        );
+    }
+    #[test]
+    fn metrics_count_failures_without_committing_tokens() {
+        let m = ExecutionMetrics::new("test", 100);
+        let p = ExecutionPlan::eager(Phase::Verify, 1, 4, WorkspaceUse::Runtime);
+        p.execute(&m, |_| Ok(())).unwrap();
+        assert!(
+            p.execute(&m, |_| Err::<(), _>(OpError::Shape("failed".into())))
+                .is_err()
+        );
+        let s = m.snapshot(Phase::Verify);
+        assert_eq!((s.calls, s.failures, s.tokens), (2, 1, 4));
+        m.committed(3, 2, 3, 3);
+        m.committed(0, 0, 1, 1);
+        let t = m.token_snapshot();
+        assert_eq!((t.rounds, t.proposed, t.accepted, t.emitted), (2, 3, 2, 4));
+    }
+    #[test]
+    fn disabled_stats_still_execute_and_propagate_errors() {
+        let m = ExecutionMetrics::default();
+        let p = ExecutionPlan::eager(Phase::Draft, 1, 0, WorkspaceUse::Proposer);
+        assert_eq!(p.execute(&m, |_| Ok(42)).unwrap(), 42);
+        assert_eq!(m.snapshot(Phase::Draft).calls, 0);
+    }
+}

--- a/crates/infer-worker/src/application/mod.rs
+++ b/crates/infer-worker/src/application/mod.rs
@@ -10,7 +10,10 @@ pub mod kv_relief;
 pub mod runtime;
 pub mod sampler_stack;
 #[cfg(feature = "cuda")]
+pub mod serve_execution;
+#[cfg(feature = "cuda")]
 pub mod serve_loop;
+pub mod speculative;
 #[cfg(feature = "cuda")]
 pub mod tensor_parallel;
 pub mod tuning;

--- a/crates/infer-worker/src/application/mod.rs
+++ b/crates/infer-worker/src/application/mod.rs
@@ -4,6 +4,7 @@
 pub mod decode_common;
 #[cfg(feature = "cuda")]
 pub mod decode_engine;
+pub mod execution;
 pub mod hosting;
 #[cfg(feature = "cuda")]
 pub mod kv_relief;

--- a/crates/infer-worker/src/application/runtime/abc_decode.rs
+++ b/crates/infer-worker/src/application/runtime/abc_decode.rs
@@ -1,6 +1,7 @@
 //! ABC GPU-resident pipelined pure-decode: the `issue_decode_abc` /
 //! `finalize_decode_abc` halves of the 1-deep decode pipeline (CUDA).
 
+use crate::application::execution::{ExecutionMode, ExecutionPlan, Phase, WorkspaceUse};
 use crate::domain::dtype::Dtype;
 use crate::domain::exec::ExecScope;
 use crate::domain::model::DecoderModel;
@@ -289,28 +290,37 @@ where
                 // decision never reaches here; treat it as eager for exhaustiveness.
                 GraphDecision::PrefillGraph(_) | GraphDecision::Eager => None,
             };
-            match slot_batch {
-                Some(sb) if self.scope.graph_ready(sb as u64) => {
-                    // Hot path: pure replay of the (>= batch) captured graph.
-                    tracing::debug!(
-                        batch,
-                        capture_batch = sb,
-                        multimodal = self.request_is_multimodal(req),
-                        "replaying decode CUDA graph"
-                    );
-                    self.launch_decode_graph(sb as u64)?;
+            let mode = match slot_batch {
+                Some(slot) if self.scope.graph_ready(slot as u64) => {
+                    ExecutionMode::DecodeGraph { slot }
                 }
-                // No ready graph for this shape (boot prewarm off/failed, or
-                // batch > max capture size): run EAGER at the real batch. We never
-                // capture inline at serve time — an inline capture is a full eager
-                // forward + `synchronize` + trace pass that blocks the serve loop
-                // (and every prefill queued behind it); that lazy capture WAS the
-                // original TTFT/TPOT stall. Every decode graph is captured once at
-                // boot by `prewarm_decode_graphs`; serving only replays or runs eager.
-                _ => {
-                    self.forward_finalize_argmax(&plan, &input_ids)?;
-                }
-            }
+                _ => ExecutionMode::Eager,
+            };
+            let execution = ExecutionPlan {
+                phase: Phase::Decode,
+                mode,
+                batch,
+                tokens: batch,
+                workspace: WorkspaceUse::Abc,
+            };
+            execution.execute(
+                &self.execution_metrics.clone(),
+                |execution| match execution.mode {
+                    ExecutionMode::DecodeGraph { slot } => {
+                        tracing::debug!(
+                            batch,
+                            capture_batch = slot,
+                            multimodal = self.request_is_multimodal(req),
+                            "replaying decode CUDA graph"
+                        );
+                        self.launch_decode_graph(slot as u64)
+                    }
+                    ExecutionMode::Eager => self.forward_finalize_argmax(&plan, &input_ids),
+                    ExecutionMode::PrefillGraph { .. } | ExecutionMode::MixedGraph { .. } => {
+                        unreachable!("validated decode plan")
+                    }
+                },
+            )?;
 
             // C feeds both stop evaluation and row compaction below. Synchronize
             // the sampled ids first so every rank takes the same active/finished
@@ -488,7 +498,10 @@ where
 
     fn finalize_decode_abc_local(&mut self, batch: usize) -> OpResult<DecodeCompactOutput> {
         let result = (|| {
-            let sync_result = D::pipeline_synchronize_copy_out(&self.scope);
+            let sync_result = ExecutionPlan::eager(Phase::Wait, batch, batch, WorkspaceUse::Abc)
+                .execute(&self.execution_metrics, |_| {
+                    D::pipeline_synchronize_copy_out(&self.scope)
+                });
             sync_result?; // host mirrors valid before we read them
 
             let active_n = self.abc.counts_host[0].max(0) as usize;

--- a/crates/infer-worker/src/application/runtime/abc_decode.rs
+++ b/crates/infer-worker/src/application/runtime/abc_decode.rs
@@ -190,274 +190,283 @@ where
         // Lazily page-lock the host staging on the first step so the Si/So
         // copies are truly async (pageable memory makes them host-synchronous).
         self.prepare_recurrent(req, &plan)?;
-        self.ensure_abc_pinned()?;
+        let result = (|| {
+            self.ensure_abc_pinned()?;
 
-        // Async path: when reusing the device-resident control plane, this
-        // step's block tables / kv_lens / positions were left on device by the
-        // previous step's `compact_extend_control`; skip the host rebuild +
-        // upload entirely. Otherwise (proven path, or first/post-change async
-        // step) seed the device control from the host request as usual.
-        if async_next_slots.is_some() && reuse_device_control {
-            // compact_extend_control advances physical KV positions. Image
-            // decode has a separate RoPE offset; refresh only this O(batch)
-            // index from the current request order, retaining device KV reuse.
-            if self.request_is_multimodal(req) {
+            // Async path: when reusing the device-resident control plane, this
+            // step's block tables / kv_lens / positions were left on device by the
+            // previous step's `compact_extend_control`; skip the host rebuild +
+            // upload entirely. Otherwise (proven path, or first/post-change async
+            // step) seed the device control from the host request as usual.
+            if async_next_slots.is_some() && reuse_device_control {
+                // compact_extend_control advances physical KV positions. Image
+                // decode has a separate RoPE offset; refresh only this O(batch)
+                // index from the current request order, retaining device KV reuse.
+                if self.request_is_multimodal(req) {
+                    unsafe {
+                        upload_i32_prefix(
+                            self.scope.device(),
+                            &self.kv_index.rope_positions,
+                            &plan.rope_positions,
+                        )?;
+                    }
+                }
+            } else {
+                self.upload_index(&plan, req)?;
+            }
+
+            // Guard A against this step's append/merge overwriting it before the
+            // prior step's copy-out (So) finished reading A_{n-1}. (ev_out)
+            if self.abc.copy_out_recorded {
+                D::pipeline_compute_wait_copy_out(&self.scope)?;
+            }
+
+            // ── Refresh A: only the divergent suffix (rows >= a_valid_prefix). ──
+            // Rows 0..vp already hold the right token from the prior step's merge.
+            // B is uploaded on the copy-in stream (Si) so it can overlap compute;
+            // the append (compute) waits on ev_in before reading B.
+            let vp = a_valid_prefix.min(batch);
+            if vp < batch {
+                let n = batch - vp;
+                // WAR guard: the prior step's copy-in DMA may still be reading
+                // `new_token_host`. Drain Si before the CPU overwrites it. Cheap
+                // (Si is a tiny copy, usually long idle by now) and only on
+                // admission steps. Mandatory for correctness once this staging
+                // buffer is page-locked (pinned), where the H2D is truly async.
+                D::pipeline_synchronize_copy_in(&self.scope)?;
+                for (dst, seq) in self.abc.new_token_host[..n]
+                    .iter_mut()
+                    .zip(req.seqs[vp..].iter())
+                {
+                    *dst = seq.input_ids[0];
+                }
+                let _guard = self.scope.enter();
                 unsafe {
-                    upload_i32_prefix(
-                        self.scope.device(),
-                        &self.kv_index.rope_positions,
-                        &plan.rope_positions,
+                    D::pipeline_upload_h2d_copy_in(
+                        &self.scope,
+                        self.abc.new_token_dev.data_ptr_mut() as *mut std::ffi::c_void,
+                        self.abc.new_token_host.as_ptr() as *const std::ffi::c_void,
+                        n * std::mem::size_of::<i32>(),
                     )?;
                 }
-            }
-        } else {
-            self.upload_index(&plan, req)?;
-        }
-
-        // Guard A against this step's append/merge overwriting it before the
-        // prior step's copy-out (So) finished reading A_{n-1}. (ev_out)
-        if self.abc.copy_out_recorded {
-            D::pipeline_compute_wait_copy_out(&self.scope)?;
-        }
-
-        // ── Refresh A: only the divergent suffix (rows >= a_valid_prefix). ──
-        // Rows 0..vp already hold the right token from the prior step's merge.
-        // B is uploaded on the copy-in stream (Si) so it can overlap compute;
-        // the append (compute) waits on ev_in before reading B.
-        let vp = a_valid_prefix.min(batch);
-        if vp < batch {
-            let n = batch - vp;
-            // WAR guard: the prior step's copy-in DMA may still be reading
-            // `new_token_host`. Drain Si before the CPU overwrites it. Cheap
-            // (Si is a tiny copy, usually long idle by now) and only on
-            // admission steps. Mandatory for correctness once this staging
-            // buffer is page-locked (pinned), where the H2D is truly async.
-            D::pipeline_synchronize_copy_in(&self.scope)?;
-            for (dst, seq) in self.abc.new_token_host[..n]
-                .iter_mut()
-                .zip(req.seqs[vp..].iter())
-            {
-                *dst = seq.input_ids[0];
-            }
-            let _guard = self.scope.enter();
-            unsafe {
-                D::pipeline_upload_h2d_copy_in(
+                D::pipeline_record_copy_in(&self.scope)?; // ev_in on Si
+                // Compute waits ev_in before reading B.
+                D::pipeline_compute_wait_copy_in(&self.scope)?;
+                D::append_decode_admissions(
                     &self.scope,
-                    self.abc.new_token_dev.data_ptr_mut() as *mut std::ffi::c_void,
-                    self.abc.new_token_host.as_ptr() as *const std::ffi::c_void,
-                    n * std::mem::size_of::<i32>(),
+                    &mut self.input_ids_buf,
+                    &self.abc.new_token_dev,
+                    vp,
+                    n,
                 )?;
             }
-            D::pipeline_record_copy_in(&self.scope)?; // ev_in on Si
-            // Compute waits ev_in before reading B.
-            D::pipeline_compute_wait_copy_in(&self.scope)?;
-            D::append_decode_admissions(
-                &self.scope,
-                &mut self.input_ids_buf,
-                &self.abc.new_token_dev,
-                vp,
-                n,
-            )?;
-        }
 
-        // ── forward + finalize + in-graph argmax → buffer C ──
-        let input_ids = self.input_ids_buf.view_raw(
-            Shape::from_slice(&[batch]),
-            Shape::from_slice(&[batch]).contiguous_strides(),
-            0,
-            true,
-        );
-        // Pad the live decode batch UP to the next captured graph size and
-        // replay that (possibly larger) graph. `slot_for_batch` rounds `batch`
-        // up to the smallest capture size >= batch; replaying it is correct
-        // because the per-seq control buffers are zero-padded to capacity, so
-        // the tail rows [batch, slot) carry q_len=0 / kv_len=0: the KV scatter
-        // writes nothing and paged attention reads nothing for them, and the
-        // forward is per-row independent (no cross-row reduction), so their
-        // garbage output lands only in C[batch..slot], which the merge — run at
-        // the real `batch` (old_batch=batch) — never reads. This eliminates the
-        // eager fallback that every NON-capture batch size used to take: an
-        // eager `forward_finalize_argmax` on a cold (batch × kv_len) shape pays
-        // the full lazy cuDNN-SDPA-plan + cuBLASLt-algo build (~400ms measured),
-        // inline on the serve thread — the dominant wandering TTFT/TPOT tail
-        // spike under load ("抖动"). With boot prewarm every slot is ready, so
-        // this is a pure replay.
-        let slot_batch = match self.decide(&plan) {
-            GraphDecision::Graph(slot) => self.graph.as_ref().and_then(|g| g.slot_size(slot)),
-            // This ABC path only runs for decode-only steps, so a prefill-graph
-            // decision never reaches here; treat it as eager for exhaustiveness.
-            GraphDecision::PrefillGraph(_) | GraphDecision::Eager => None,
-        };
-        match slot_batch {
-            Some(sb) if self.scope.graph_ready(sb as u64) => {
-                // Hot path: pure replay of the (>= batch) captured graph.
-                tracing::debug!(
-                    batch,
-                    capture_batch = sb,
-                    multimodal = self.request_is_multimodal(req),
-                    "replaying decode CUDA graph"
-                );
-                self.launch_decode_graph(sb as u64)?;
-            }
-            // No ready graph for this shape (boot prewarm off/failed, or
-            // batch > max capture size): run EAGER at the real batch. We never
-            // capture inline at serve time — an inline capture is a full eager
-            // forward + `synchronize` + trace pass that blocks the serve loop
-            // (and every prefill queued behind it); that lazy capture WAS the
-            // original TTFT/TPOT stall. Every decode graph is captured once at
-            // boot by `prewarm_decode_graphs`; serving only replays or runs eager.
-            _ => {
-                self.forward_finalize_argmax(&plan, &input_ids)?;
-            }
-        }
-
-        // C feeds both stop evaluation and row compaction below. Synchronize
-        // the sampled ids first so every rank takes the same active/finished
-        // branches and enters subsequent collectives with identical row state.
-        self.broadcast_tp_argmax(batch)?;
-
-        // ── upload stop metadata + run the compact merge (C → A) ──
-        let gen_i32: Vec<i32> = generated_counts
-            .iter()
-            .map(|&x| u32_to_i32_saturating(x))
-            .collect();
-        let max_i32: Vec<i32> = max_tokens
-            .iter()
-            .map(|&x| u32_to_i32_saturating(x))
-            .collect();
-        let ign_i32: Vec<i32> = ignore_eos.iter().map(|&b| i32::from(b)).collect();
-        let device = self.scope.device();
-        unsafe {
-            upload_i32_prefix(device, &self.abc.generated_counts_dev, &gen_i32)?;
-            upload_i32_prefix(device, &self.abc.max_tokens_dev, &max_i32)?;
-            upload_i32_prefix(device, &self.abc.ignore_eos_dev, &ign_i32)?;
-            if !eos_ids.is_empty() {
-                upload_i32_prefix(device, &self.abc.eos_ids_dev, eos_ids)?;
-            }
-        }
-        {
-            let _guard = self.scope.enter();
-            let mut a = self.input_ids_buf.view_raw(
+            // ── forward + finalize + in-graph argmax → buffer C ──
+            let input_ids = self.input_ids_buf.view_raw(
                 Shape::from_slice(&[batch]),
                 Shape::from_slice(&[batch]).contiguous_strides(),
                 0,
                 true,
             );
-            D::merge_compact_decode(
-                &self.scope,
-                MergeCompactDecodeArgs {
-                    a_out: &mut a,
-                    c_prev: &self.abc.argmax_out_dev,
-                    generated_counts: &self.abc.generated_counts_dev,
-                    max_tokens: &self.abc.max_tokens_dev,
-                    ignore_eos: &self.abc.ignore_eos_dev,
-                    eos_ids: &self.abc.eos_ids_dev,
-                    eos_len: eos_ids.len(),
-                    old_batch: batch,
-                    active_src_rows: &mut self.abc.active_src_rows_dev,
-                    finished_src_rows: &mut self.abc.finished_src_rows_dev,
-                    finished_tokens: &mut self.abc.finished_tokens_dev,
-                    counts: &mut self.abc.counts_dev,
-                },
-            )?;
-        }
-
-        // ── Async path: build NEXT step's device control plane on-device ──
-        // After the merge has produced `active_src_rows` + `counts`, gather the
-        // surviving rows' block tables / kv_lens to the compacted front, append
-        // each row's next-step KV slot, advance position/length, and rebuild the
-        // decode tile layout — replacing the host O(batch*seq_len) rebuild +
-        // upload with O(batch) device work. Runs on the compute stream after the
-        // merge; the next step's forward (after the finalize sync) reads the
-        // result. `new_slots` are the Stage-1 speculative reservations.
-        if let Some(next_slots) = async_next_slots {
-            self.ensure_async_ctrl()?;
-            let device = self.scope.device();
-            // Upload the next-step slots (O(batch)); the kernel uses the first
-            // `active` of them (active is device-resident).
-            let slots_i32: Vec<i32> = next_slots.iter().map(|&s| s as i32).collect();
-            {
-                let ctrl = self.async_ctrl.as_ref().expect("async_ctrl ensured");
-                unsafe {
-                    upload_i32_prefix(device, &ctrl.new_slots_dev, &slots_i32)?;
+            // Pad the live decode batch UP to the next captured graph size and
+            // replay that (possibly larger) graph. `slot_for_batch` rounds `batch`
+            // up to the smallest capture size >= batch; replaying it is correct
+            // because the per-seq control buffers are zero-padded to capacity, so
+            // the tail rows [batch, slot) carry q_len=0 / kv_len=0: the KV scatter
+            // writes nothing and paged attention reads nothing for them, and the
+            // forward is per-row independent (no cross-row reduction), so their
+            // garbage output lands only in C[batch..slot], which the merge — run at
+            // the real `batch` (old_batch=batch) — never reads. This eliminates the
+            // eager fallback that every NON-capture batch size used to take: an
+            // eager `forward_finalize_argmax` on a cold (batch × kv_len) shape pays
+            // the full lazy cuDNN-SDPA-plan + cuBLASLt-algo build (~400ms measured),
+            // inline on the serve thread — the dominant wandering TTFT/TPOT tail
+            // spike under load ("抖动"). With boot prewarm every slot is ready, so
+            // this is a pure replay.
+            let slot_batch = match self.decide(&plan) {
+                GraphDecision::Graph(slot) => self.graph.as_ref().and_then(|g| g.slot_size(slot)),
+                // This ABC path only runs for decode-only steps, so a prefill-graph
+                // decision never reaches here; treat it as eager for exhaustiveness.
+                GraphDecision::PrefillGraph(_) | GraphDecision::Eager => None,
+            };
+            match slot_batch {
+                Some(sb) if self.scope.graph_ready(sb as u64) => {
+                    // Hot path: pure replay of the (>= batch) captured graph.
+                    tracing::debug!(
+                        batch,
+                        capture_batch = sb,
+                        multimodal = self.request_is_multimodal(req),
+                        "replaying decode CUDA graph"
+                    );
+                    self.launch_decode_graph(sb as u64)?;
+                }
+                // No ready graph for this shape (boot prewarm off/failed, or
+                // batch > max capture size): run EAGER at the real batch. We never
+                // capture inline at serve time — an inline capture is a full eager
+                // forward + `synchronize` + trace pass that blocks the serve loop
+                // (and every prefill queued behind it); that lazy capture WAS the
+                // original TTFT/TPOT stall. Every decode graph is captured once at
+                // boot by `prewarm_decode_graphs`; serving only replays or runs eager.
+                _ => {
+                    self.forward_finalize_argmax(&plan, &input_ids)?;
                 }
             }
-            let mbps = self.max_blocks_per_seq;
-            let cap_batch = slot_batch.unwrap_or(batch).clamp(1, self.cap_batch);
-            let _guard = self.scope.enter();
-            let ctrl = self.async_ctrl.as_mut().expect("async_ctrl ensured");
-            D::compact_extend_control(
-                &self.scope,
-                CompactExtendControlArgs {
-                    block_tables: &mut self.kv_index.block_tables,
-                    block_tables_scratch: &mut ctrl.block_tables_scratch,
-                    kv_lens: &mut self.kv_index.kv_lens,
-                    kv_lens_scratch: &mut ctrl.kv_lens_scratch,
-                    seq_positions_out: &mut self.kv_index.seq_positions,
-                    seq_lens_step_out: &mut self.kv_index.seq_lens_step,
-                    rope_positions_out: &mut self.kv_index.rope_positions,
-                    cu_q_lens_out: &mut self.kv_index.cu_q_lens,
-                    block2req_out: &mut self.kv_index.block2req,
-                    block2tile_out: &mut self.kv_index.block2tile,
-                    active_src_rows: &self.abc.active_src_rows_dev,
-                    counts: &self.abc.counts_dev,
-                    new_slots: &ctrl.new_slots_dev,
-                    mbps,
-                    cap_batch,
-                },
-            )?;
-        }
 
-        // A now holds the committed/compacted tokens (compute). Mark it so the
-        // copy-out stream may begin downloading once compute reaches here. (ev_a)
-        D::pipeline_record_compute_a(&self.scope)?;
+            // C feeds both stop evaluation and row compaction below. Synchronize
+            // the sampled ids first so every rank takes the same active/finished
+            // branches and enters subsequent collectives with identical row state.
+            self.broadcast_tp_argmax(batch)?;
 
-        // ── download the compaction maps on the copy-out stream (So) ──
-        // So waits ev_a, then the D2H runs (and may overlap the next step's
-        // forward). Fixed `batch`-sized chunks avoid a dependency on the (still
-        // on-device) counts. ev_out gates the next step's A overwrite.
-        D::pipeline_copy_out_wait_compute_a(&self.scope)?;
-        let bytes = batch * std::mem::size_of::<i32>();
-        let elem = std::mem::size_of::<i32>();
-        unsafe {
-            D::pipeline_download_d2h_copy_out(
-                &self.scope,
-                self.abc.counts_host.as_mut_ptr() as *mut std::ffi::c_void,
-                self.abc.counts_dev.data_ptr() as *const std::ffi::c_void,
-                3 * elem,
-            )?;
-            D::pipeline_download_d2h_copy_out(
-                &self.scope,
-                self.abc.active_src_rows_host.as_mut_ptr() as *mut std::ffi::c_void,
-                self.abc.active_src_rows_dev.data_ptr() as *const std::ffi::c_void,
-                bytes,
-            )?;
-            // Active tokens live in A[0..active] after the compaction.
-            D::pipeline_download_d2h_copy_out(
-                &self.scope,
-                self.abc.active_tokens_host.as_mut_ptr() as *mut std::ffi::c_void,
-                self.input_ids_buf.data_ptr() as *const std::ffi::c_void,
-                bytes,
-            )?;
-            D::pipeline_download_d2h_copy_out(
-                &self.scope,
-                self.abc.finished_src_rows_host.as_mut_ptr() as *mut std::ffi::c_void,
-                self.abc.finished_src_rows_dev.data_ptr() as *const std::ffi::c_void,
-                bytes,
-            )?;
-            D::pipeline_download_d2h_copy_out(
-                &self.scope,
-                self.abc.finished_tokens_host.as_mut_ptr() as *mut std::ffi::c_void,
-                self.abc.finished_tokens_dev.data_ptr() as *const std::ffi::c_void,
-                bytes,
-            )?;
+            // ── upload stop metadata + run the compact merge (C → A) ──
+            let gen_i32: Vec<i32> = generated_counts
+                .iter()
+                .map(|&x| u32_to_i32_saturating(x))
+                .collect();
+            let max_i32: Vec<i32> = max_tokens
+                .iter()
+                .map(|&x| u32_to_i32_saturating(x))
+                .collect();
+            let ign_i32: Vec<i32> = ignore_eos.iter().map(|&b| i32::from(b)).collect();
+            let device = self.scope.device();
+            unsafe {
+                upload_i32_prefix(device, &self.abc.generated_counts_dev, &gen_i32)?;
+                upload_i32_prefix(device, &self.abc.max_tokens_dev, &max_i32)?;
+                upload_i32_prefix(device, &self.abc.ignore_eos_dev, &ign_i32)?;
+                if !eos_ids.is_empty() {
+                    upload_i32_prefix(device, &self.abc.eos_ids_dev, eos_ids)?;
+                }
+            }
+            {
+                let _guard = self.scope.enter();
+                let mut a = self.input_ids_buf.view_raw(
+                    Shape::from_slice(&[batch]),
+                    Shape::from_slice(&[batch]).contiguous_strides(),
+                    0,
+                    true,
+                );
+                D::merge_compact_decode(
+                    &self.scope,
+                    MergeCompactDecodeArgs {
+                        a_out: &mut a,
+                        c_prev: &self.abc.argmax_out_dev,
+                        generated_counts: &self.abc.generated_counts_dev,
+                        max_tokens: &self.abc.max_tokens_dev,
+                        ignore_eos: &self.abc.ignore_eos_dev,
+                        eos_ids: &self.abc.eos_ids_dev,
+                        eos_len: eos_ids.len(),
+                        old_batch: batch,
+                        active_src_rows: &mut self.abc.active_src_rows_dev,
+                        finished_src_rows: &mut self.abc.finished_src_rows_dev,
+                        finished_tokens: &mut self.abc.finished_tokens_dev,
+                        counts: &mut self.abc.counts_dev,
+                    },
+                )?;
+            }
+
+            // ── Async path: build NEXT step's device control plane on-device ──
+            // After the merge has produced `active_src_rows` + `counts`, gather the
+            // surviving rows' block tables / kv_lens to the compacted front, append
+            // each row's next-step KV slot, advance position/length, and rebuild the
+            // decode tile layout — replacing the host O(batch*seq_len) rebuild +
+            // upload with O(batch) device work. Runs on the compute stream after the
+            // merge; the next step's forward (after the finalize sync) reads the
+            // result. `new_slots` are the Stage-1 speculative reservations.
+            if let Some(next_slots) = async_next_slots {
+                self.ensure_async_ctrl()?;
+                let device = self.scope.device();
+                // Upload the next-step slots (O(batch)); the kernel uses the first
+                // `active` of them (active is device-resident).
+                let slots_i32: Vec<i32> = next_slots.iter().map(|&s| s as i32).collect();
+                {
+                    let ctrl = self.async_ctrl.as_ref().expect("async_ctrl ensured");
+                    unsafe {
+                        upload_i32_prefix(device, &ctrl.new_slots_dev, &slots_i32)?;
+                    }
+                }
+                let mbps = self.max_blocks_per_seq;
+                let cap_batch = slot_batch.unwrap_or(batch).clamp(1, self.cap_batch);
+                let _guard = self.scope.enter();
+                let ctrl = self.async_ctrl.as_mut().expect("async_ctrl ensured");
+                D::compact_extend_control(
+                    &self.scope,
+                    CompactExtendControlArgs {
+                        block_tables: &mut self.kv_index.block_tables,
+                        block_tables_scratch: &mut ctrl.block_tables_scratch,
+                        kv_lens: &mut self.kv_index.kv_lens,
+                        kv_lens_scratch: &mut ctrl.kv_lens_scratch,
+                        seq_positions_out: &mut self.kv_index.seq_positions,
+                        seq_lens_step_out: &mut self.kv_index.seq_lens_step,
+                        rope_positions_out: &mut self.kv_index.rope_positions,
+                        cu_q_lens_out: &mut self.kv_index.cu_q_lens,
+                        block2req_out: &mut self.kv_index.block2req,
+                        block2tile_out: &mut self.kv_index.block2tile,
+                        active_src_rows: &self.abc.active_src_rows_dev,
+                        counts: &self.abc.counts_dev,
+                        new_slots: &ctrl.new_slots_dev,
+                        mbps,
+                        cap_batch,
+                    },
+                )?;
+            }
+
+            // A now holds the committed/compacted tokens (compute). Mark it so the
+            // copy-out stream may begin downloading once compute reaches here. (ev_a)
+            D::pipeline_record_compute_a(&self.scope)?;
+
+            // ── download the compaction maps on the copy-out stream (So) ──
+            // So waits ev_a, then the D2H runs (and may overlap the next step's
+            // forward). Fixed `batch`-sized chunks avoid a dependency on the (still
+            // on-device) counts. ev_out gates the next step's A overwrite.
+            D::pipeline_copy_out_wait_compute_a(&self.scope)?;
+            let bytes = batch * std::mem::size_of::<i32>();
+            let elem = std::mem::size_of::<i32>();
+            unsafe {
+                D::pipeline_download_d2h_copy_out(
+                    &self.scope,
+                    self.abc.counts_host.as_mut_ptr() as *mut std::ffi::c_void,
+                    self.abc.counts_dev.data_ptr() as *const std::ffi::c_void,
+                    3 * elem,
+                )?;
+                D::pipeline_download_d2h_copy_out(
+                    &self.scope,
+                    self.abc.active_src_rows_host.as_mut_ptr() as *mut std::ffi::c_void,
+                    self.abc.active_src_rows_dev.data_ptr() as *const std::ffi::c_void,
+                    bytes,
+                )?;
+                // Active tokens live in A[0..active] after the compaction.
+                D::pipeline_download_d2h_copy_out(
+                    &self.scope,
+                    self.abc.active_tokens_host.as_mut_ptr() as *mut std::ffi::c_void,
+                    self.input_ids_buf.data_ptr() as *const std::ffi::c_void,
+                    bytes,
+                )?;
+                D::pipeline_download_d2h_copy_out(
+                    &self.scope,
+                    self.abc.finished_src_rows_host.as_mut_ptr() as *mut std::ffi::c_void,
+                    self.abc.finished_src_rows_dev.data_ptr() as *const std::ffi::c_void,
+                    bytes,
+                )?;
+                D::pipeline_download_d2h_copy_out(
+                    &self.scope,
+                    self.abc.finished_tokens_host.as_mut_ptr() as *mut std::ffi::c_void,
+                    self.abc.finished_tokens_dev.data_ptr() as *const std::ffi::c_void,
+                    bytes,
+                )?;
+            }
+            D::pipeline_record_copy_out(&self.scope)?; // ev_out on So
+            self.abc.copy_out_recorded = true;
+            // NOTE: no synchronize here — the So download runs asynchronously and is
+            // collected by `finalize_decode_abc`, which the caller invokes one step
+            // later so the next step's compute overlaps this step's host commit.
+            Ok(())
+        })();
+        let result = self.finish_recurrent_step(result);
+        if result.is_ok()
+            && let Some(state) = &mut self.recurrent
+        {
+            state.record_decode_issue(req);
         }
-        D::pipeline_record_copy_out(&self.scope)?; // ev_out on So
-        self.abc.copy_out_recorded = true;
-        // NOTE: no synchronize here — the So download runs asynchronously and is
-        // collected by `finalize_decode_abc`, which the caller invokes one step
-        // later so the next step's compute overlaps this step's host commit.
-        Ok(())
+        result
     }
 
     /// Collect the result of the in-flight `issue_decode_abc` step: drain the
@@ -478,58 +487,64 @@ where
     }
 
     fn finalize_decode_abc_local(&mut self, batch: usize) -> OpResult<DecodeCompactOutput> {
-        let sync_result = D::pipeline_synchronize_copy_out(&self.scope);
-        sync_result?; // host mirrors valid before we read them
+        let result = (|| {
+            let sync_result = D::pipeline_synchronize_copy_out(&self.scope);
+            sync_result?; // host mirrors valid before we read them
 
-        let active_n = self.abc.counts_host[0].max(0) as usize;
-        let finished_n = self.abc.counts_host[1].max(0) as usize;
-        let old_n = self.abc.counts_host[2].max(0) as usize;
-        if old_n != batch || active_n + finished_n != batch {
-            return Err(OpError::Kernel(format!(
-                "step_decode_abc: compact counts invalid active={} finished={} old={} batch={}",
-                active_n, finished_n, old_n, batch
-            )));
-        }
-        let mut seen = vec![false; batch];
-        let mut mark = |src: i32| -> OpResult<usize> {
-            let row = src as usize;
-            if row >= batch {
+            let active_n = self.abc.counts_host[0].max(0) as usize;
+            let finished_n = self.abc.counts_host[1].max(0) as usize;
+            let old_n = self.abc.counts_host[2].max(0) as usize;
+            if old_n != batch || active_n + finished_n != batch {
                 return Err(OpError::Kernel(format!(
-                    "step_decode_abc: src_row {} >= batch {}",
-                    row, batch
+                    "step_decode_abc: compact counts invalid active={} finished={} old={} batch={}",
+                    active_n, finished_n, old_n, batch
                 )));
             }
-            if seen[row] {
-                return Err(OpError::Kernel(format!(
-                    "step_decode_abc: src_row {} returned twice",
-                    row
-                )));
+            let mut seen = vec![false; batch];
+            let mut mark = |src: i32| -> OpResult<usize> {
+                let row = src as usize;
+                if row >= batch {
+                    return Err(OpError::Kernel(format!(
+                        "step_decode_abc: src_row {} >= batch {}",
+                        row, batch
+                    )));
+                }
+                if seen[row] {
+                    return Err(OpError::Kernel(format!(
+                        "step_decode_abc: src_row {} returned twice",
+                        row
+                    )));
+                }
+                seen[row] = true;
+                Ok(row)
+            };
+            let mut active = Vec::with_capacity(active_n);
+            for k in 0..active_n {
+                let row = mark(self.abc.active_src_rows_host[k])?;
+                active.push(DecodeRowToken {
+                    src_row: row,
+                    token_id: self.abc.active_tokens_host[k],
+                });
             }
-            seen[row] = true;
-            Ok(row)
-        };
-        let mut active = Vec::with_capacity(active_n);
-        for k in 0..active_n {
-            let row = mark(self.abc.active_src_rows_host[k])?;
-            active.push(DecodeRowToken {
-                src_row: row,
-                token_id: self.abc.active_tokens_host[k],
-            });
-        }
-        let mut finished = Vec::with_capacity(finished_n);
-        for j in 0..finished_n {
-            let row = mark(self.abc.finished_src_rows_host[j])?;
-            finished.push(DecodeRowToken {
-                src_row: row,
-                token_id: self.abc.finished_tokens_host[j],
-            });
-        }
-        if seen.iter().any(|covered| !*covered) {
-            return Err(OpError::Kernel(
-                "step_decode_abc: compaction did not cover every row".into(),
-            ));
-        }
+            let mut finished = Vec::with_capacity(finished_n);
+            for j in 0..finished_n {
+                let row = mark(self.abc.finished_src_rows_host[j])?;
+                finished.push(DecodeRowToken {
+                    src_row: row,
+                    token_id: self.abc.finished_tokens_host[j],
+                });
+            }
+            if seen.iter().any(|covered| !*covered) {
+                return Err(OpError::Kernel(
+                    "step_decode_abc: compaction did not cover every row".into(),
+                ));
+            }
 
-        Ok(DecodeCompactOutput { active, finished })
+            Ok(DecodeCompactOutput { active, finished })
+        })();
+        if let Some(state) = &mut self.recurrent {
+            state.collect_decode(result.is_ok());
+        }
+        result
     }
 }

--- a/crates/infer-worker/src/application/runtime/graph_exec.rs
+++ b/crates/infer-worker/src/application/runtime/graph_exec.rs
@@ -426,13 +426,10 @@ where
         self.decode_output_from_c(plan, req)
     }
 
-    /// Replay bypasses run_layers, so advance host-owned recurrent history here.
+    /// Enqueue only: the enclosing ordinary step/issue commits logical
+    /// recurrent history after its sampling and output setup succeed.
     pub(super) fn launch_decode_graph(&mut self, key: u64) -> OpResult<()> {
-        let result = self.scope.graph_launch(key);
-        if let Some(state) = &mut self.recurrent {
-            state.complete(result.is_ok());
-        }
-        result
+        self.scope.graph_launch(key)
     }
 
     /// Single-sequence prefill via CUDA graph (Stage A). The captured region is

--- a/crates/infer-worker/src/application/runtime/mixed_abc.rs
+++ b/crates/infer-worker/src/application/runtime/mixed_abc.rs
@@ -457,9 +457,12 @@ where
         let result = (|| {
             let plan = self.build_plan(req)?;
             self.prepare_recurrent(req, &plan)?;
-            self.upload_index(&plan, req)?;
-            self.prepare_multimodal(req)?;
-            self.step_eager(&plan, req)
+            let result = (|| {
+                self.upload_index(&plan, req)?;
+                self.prepare_multimodal(req)?;
+                self.step_eager(&plan, req)
+            })();
+            self.finish_recurrent_step(result)
         })();
         D::pipeline_arena_end(&self.scope);
         result
@@ -556,69 +559,79 @@ where
             }
         }
         self.prepare_recurrent(req, &plan)?;
-        if let Some(slots) = next_slots {
-            self.upload_mixed_next_slots(slots)?;
-        }
-
-        let trace = std::env::var_os("RUSTINFER_MIXED_TRACE").is_some();
-        let t0 = std::time::Instant::now();
-        let ran_graph = self.try_run_mixed_abc_graph(&plan, req, row_kind, next_slots.is_some())?;
-        if !ran_graph {
-            self.upload_index(&plan, req)?;
-            let run_plan = self.eager_mixed_run_plan(&plan);
-            let run_tokens = run_plan
-                .as_ref()
-                .map(|rp| rp.num_tokens)
-                .unwrap_or(plan.num_tokens);
-            let input_ids = if c_prefix_rows > 0 {
-                // q=1 decode rows lead the batch, so flat tape offset == row
-                // index: gather C[0..c] into the tape prefix on device and
-                // upload only the suffix (pad rows + prefill tokens + bucket
-                // zero-pad) from the host.
-                let ids =
-                    self.upload_input_ids_suffix(req, c_prefix_rows, plan.num_tokens, run_tokens)?;
-                D::append_decode_admissions(
-                    &self.scope,
-                    &mut self.prefill_ids_buf,
-                    &self.abc.argmax_out_dev,
-                    0,
-                    c_prefix_rows,
-                )?;
-                ids
-            } else if run_tokens > plan.num_tokens {
-                self.upload_input_ids_bucket(req, plan.num_tokens, run_tokens)?
-            } else {
-                self.input_ids_tensor(req, &plan)?
-            };
-            self.upload_mixed_abc_metadata(req, row_kind, plan.batch)?;
-            // WAR guard for the overlapped issue: the in-flight step's copy-out
-            // (So) reads A + the merge side-bands; make compute wait its ev_out
-            // before this region's merge rewrites them. No-op after a drain
-            // (the sync already collected the copy-out).
-            if self.abc.copy_out_recorded {
-                D::pipeline_compute_wait_copy_out(&self.scope)?;
+        let result = (|| {
+            if let Some(slots) = next_slots {
+                self.upload_mixed_next_slots(slots)?;
             }
-            D::pipeline_arena_begin(&self.scope)?;
-            let result = self.run_mixed_abc_eager_region(
-                run_plan.as_ref().unwrap_or(&plan),
-                req,
-                &input_ids,
-                next_slots.is_some(),
-            );
-            D::pipeline_arena_end(&self.scope);
-            result?;
-        }
-        let copied_out = !defer_copy_out;
-        if copied_out {
-            self.copy_out_mixed_abc(plan.batch)?;
-        }
-        Ok(MixedStepTicket {
-            plan,
-            ran_graph,
-            trace,
-            t0,
-            copied_out,
-        })
+
+            let trace = std::env::var_os("RUSTINFER_MIXED_TRACE").is_some();
+            let t0 = std::time::Instant::now();
+            let ran_graph =
+                self.try_run_mixed_abc_graph(&plan, req, row_kind, next_slots.is_some())?;
+            if !ran_graph {
+                self.upload_index(&plan, req)?;
+                let run_plan = self.eager_mixed_run_plan(&plan);
+                let run_tokens = run_plan
+                    .as_ref()
+                    .map(|rp| rp.num_tokens)
+                    .unwrap_or(plan.num_tokens);
+                let input_ids = if c_prefix_rows > 0 {
+                    // q=1 decode rows lead the batch, so flat tape offset == row
+                    // index: gather C[0..c] into the tape prefix on device and
+                    // upload only the suffix (pad rows + prefill tokens + bucket
+                    // zero-pad) from the host.
+                    let ids = self.upload_input_ids_suffix(
+                        req,
+                        c_prefix_rows,
+                        plan.num_tokens,
+                        run_tokens,
+                    )?;
+                    D::append_decode_admissions(
+                        &self.scope,
+                        &mut self.prefill_ids_buf,
+                        &self.abc.argmax_out_dev,
+                        0,
+                        c_prefix_rows,
+                    )?;
+                    ids
+                } else if run_tokens > plan.num_tokens {
+                    self.upload_input_ids_bucket(req, plan.num_tokens, run_tokens)?
+                } else {
+                    self.input_ids_tensor(req, &plan)?
+                };
+                self.upload_mixed_abc_metadata(req, row_kind, plan.batch)?;
+                // WAR guard for the overlapped issue: the in-flight step's copy-out
+                // (So) reads A + the merge side-bands; make compute wait its ev_out
+                // before this region's merge rewrites them. No-op after a drain
+                // (the sync already collected the copy-out).
+                if self.abc.copy_out_recorded {
+                    D::pipeline_compute_wait_copy_out(&self.scope)?;
+                }
+                D::pipeline_arena_begin(&self.scope)?;
+                let result = self.run_mixed_abc_eager_region(
+                    run_plan.as_ref().unwrap_or(&plan),
+                    req,
+                    &input_ids,
+                    next_slots.is_some(),
+                );
+                D::pipeline_arena_end(&self.scope);
+                result?;
+            }
+            let copied_out = !defer_copy_out;
+            if copied_out {
+                self.copy_out_mixed_abc(plan.batch)?;
+            }
+            Ok(MixedStepTicket {
+                plan,
+                ran_graph,
+                trace,
+                t0,
+                copied_out,
+            })
+        })();
+        // Ordinary ABC advances host history only after the complete issue
+        // succeeds, so a subsequent overlapping issue sees the right prefix.
+        self.finish_recurrent_step(result)
     }
 
     /// Collect a mixed step issued by `issue_fused_abc`: drain the copy-out
@@ -646,27 +659,35 @@ where
         req: &StepRequest,
         row_kind: &[RaggedRowKind],
     ) -> OpResult<StepOutput> {
-        // Overlapped issue deferred the copy-out (the host mirrors belonged to
-        // the then-in-flight decode step); by the time the caller finalizes
-        // the fused step that step has been drained, so enqueue it now.
-        if !ticket.copied_out {
-            self.copy_out_mixed_abc(ticket.plan.batch)?;
+        let result = (|| {
+            // Overlapped issue deferred the copy-out (the host mirrors belonged to
+            // the then-in-flight decode step); by the time the caller finalizes
+            // the fused step that step has been drained, so enqueue it now.
+            if !ticket.copied_out {
+                self.copy_out_mixed_abc(ticket.plan.batch)?;
+            }
+            let sync_result = D::pipeline_synchronize_copy_out(&self.scope);
+            sync_result?;
+            if ticket.trace {
+                // `elapsed` spans issue→sync, so it includes any host work the
+                // caller overlapped between the two halves.
+                tracing::info!(
+                    "[mixed-trace] mode={} rows={} tokens={} tiles={} elapsed={:.2}ms",
+                    if ticket.ran_graph { "graph" } else { "eager" },
+                    ticket.plan.batch,
+                    ticket.plan.num_tokens,
+                    ticket.plan.total_q_tiles,
+                    ticket.t0.elapsed().as_secs_f64() * 1e3
+                );
+            }
+            self.finalize_mixed_abc(&ticket.plan, req, row_kind)
+        })();
+        if result.is_err() {
+            for seq in &req.seqs {
+                self.release_sequence(seq.sequence_id);
+            }
         }
-        let sync_result = D::pipeline_synchronize_copy_out(&self.scope);
-        sync_result?;
-        if ticket.trace {
-            // `elapsed` spans issue→sync, so it includes any host work the
-            // caller overlapped between the two halves.
-            tracing::info!(
-                "[mixed-trace] mode={} rows={} tokens={} tiles={} elapsed={:.2}ms",
-                if ticket.ran_graph { "graph" } else { "eager" },
-                ticket.plan.batch,
-                ticket.plan.num_tokens,
-                ticket.plan.total_q_tiles,
-                ticket.t0.elapsed().as_secs_f64() * 1e3
-            );
-        }
-        self.finalize_mixed_abc(&ticket.plan, req, row_kind)
+        result
     }
 
     /// Synchronous mixed step: issue + finalize back-to-back. Used by the
@@ -1315,7 +1336,8 @@ where
         }
         Ok(StepOutput {
             tokens,
-            accepted: plan.q_lens.iter().map(|&q| q.max(0) as u32).collect(),
+            materialized_tokens: plan.q_lens.iter().map(|&q| q.max(0) as u32).collect(),
+            accepted_drafts: None,
             finished,
             hidden_tap: None,
         })

--- a/crates/infer-worker/src/application/runtime/mixed_abc.rs
+++ b/crates/infer-worker/src/application/runtime/mixed_abc.rs
@@ -2,6 +2,7 @@
 //! model: eager and bucketed-graph paths, issue/finalize halves, and the
 //! bootstrap mixed-graph prewarm (CUDA).
 
+use crate::application::execution::{ExecutionMode, ExecutionPlan, Phase, WorkspaceUse};
 use crate::domain::component::Hidden;
 use crate::domain::dtype::Dtype;
 use crate::domain::exec::ExecScope;
@@ -460,7 +461,15 @@ where
             let result = (|| {
                 self.upload_index(&plan, req)?;
                 self.prepare_multimodal(req)?;
-                self.step_eager(&plan, req)
+                ExecutionPlan::eager(
+                    Phase::Mixed,
+                    plan.batch,
+                    plan.num_tokens,
+                    WorkspaceUse::Runtime,
+                )
+                .execute(&self.execution_metrics.clone(), |_| {
+                    self.step_eager(&plan, req)
+                })
             })();
             self.finish_recurrent_step(result)
         })();
@@ -608,12 +617,20 @@ where
                     D::pipeline_compute_wait_copy_out(&self.scope)?;
                 }
                 D::pipeline_arena_begin(&self.scope)?;
-                let result = self.run_mixed_abc_eager_region(
-                    run_plan.as_ref().unwrap_or(&plan),
-                    req,
-                    &input_ids,
-                    next_slots.is_some(),
+                let execution = ExecutionPlan::eager(
+                    Phase::Mixed,
+                    plan.batch,
+                    plan.num_tokens,
+                    WorkspaceUse::Abc,
                 );
+                let result = execution.execute(&self.execution_metrics.clone(), |_| {
+                    self.run_mixed_abc_eager_region(
+                        run_plan.as_ref().unwrap_or(&plan),
+                        req,
+                        &input_ids,
+                        next_slots.is_some(),
+                    )
+                });
                 D::pipeline_arena_end(&self.scope);
                 result?;
             }
@@ -666,7 +683,15 @@ where
             if !ticket.copied_out {
                 self.copy_out_mixed_abc(ticket.plan.batch)?;
             }
-            let sync_result = D::pipeline_synchronize_copy_out(&self.scope);
+            let sync_result = ExecutionPlan::eager(
+                Phase::Wait,
+                ticket.plan.batch,
+                ticket.plan.num_tokens,
+                WorkspaceUse::Abc,
+            )
+            .execute(&self.execution_metrics, |_| {
+                D::pipeline_synchronize_copy_out(&self.scope)
+            });
             sync_result?;
             if ticket.trace {
                 // `elapsed` spans issue→sync, so it includes any host work the
@@ -781,7 +806,19 @@ where
             self.upload_index_with_suffix_prefix(plan, req, Some(shape.decode_prefix))?;
             self.upload_input_ids_bucket(req, plan.num_tokens, shape.tokens)?;
             self.upload_mixed_abc_metadata(req, row_kind, shape.rows)?;
-            self.scope.graph_launch(key)?;
+            ExecutionPlan {
+                phase: Phase::Mixed,
+                mode: ExecutionMode::MixedGraph { key },
+                batch: plan.batch,
+                tokens: plan.num_tokens,
+                workspace: WorkspaceUse::Abc,
+            }
+            .execute(&self.execution_metrics, |execution| {
+                let ExecutionMode::MixedGraph { key } = execution.mode else {
+                    unreachable!()
+                };
+                self.scope.graph_launch(key)
+            })?;
             return Ok(true);
         }
         if !self.mixed_graph_capture_enabled {
@@ -843,7 +880,19 @@ where
             self.mixed_graphs_captured,
             MIXED_GRAPH_BUDGET
         );
-        self.scope.graph_launch(key)?;
+        ExecutionPlan {
+            phase: Phase::Mixed,
+            mode: ExecutionMode::MixedGraph { key },
+            batch: plan.batch,
+            tokens: plan.num_tokens,
+            workspace: WorkspaceUse::Abc,
+        }
+        .execute(&self.execution_metrics, |execution| {
+            let ExecutionMode::MixedGraph { key } = execution.mode else {
+                unreachable!()
+            };
+            self.scope.graph_launch(key)
+        })?;
         Ok(true)
     }
 

--- a/crates/infer-worker/src/application/runtime/mod.rs
+++ b/crates/infer-worker/src/application/runtime/mod.rs
@@ -9,6 +9,9 @@
 //! This file keeps the `Runtime` struct and its address-stable buffers,
 //! construction, the eager step path, and the shared free helpers.
 
+use crate::application::execution::{
+    ExecutionMetrics, ExecutionMode, ExecutionPlan, Phase, WorkspaceUse,
+};
 use std::ptr::NonNull;
 
 use crate::domain::component::{Hidden, LayerRange};
@@ -51,6 +54,7 @@ where
     D: LlmBackend,
     M: DecoderModel<T, D>,
 {
+    pub execution_metrics: ExecutionMetrics,
     pub model: M,
     recurrent: Option<recurrent::RecurrentState<T, D>>,
     retained_request: Option<StepRequest>,
@@ -491,7 +495,10 @@ where
             }
         };
 
+        let execution_metrics = ExecutionMetrics::from_env("target");
+        execution_metrics.prepare_gpu(&scope)?;
         Ok(Self {
+            execution_metrics,
             recurrent,
             retained_request: None,
             visual: multimodal::VisualState::default(),
@@ -634,13 +641,43 @@ where
             } else {
                 self.decide(&plan)
             };
-            match decision {
-                GraphDecision::Eager => self.step_eager(&plan, req),
-                GraphDecision::Graph(slot) => self.step_graph(slot, &plan, req),
-                GraphDecision::PrefillGraph(num_tokens) => {
-                    self.step_prefill_graph(num_tokens, &plan, req)
-                }
-            }
+            let execution = ExecutionPlan {
+                phase: if plan.q_lens.iter().all(|&q| q == 1) {
+                    Phase::Decode
+                } else {
+                    Phase::Prefill
+                },
+                mode: match decision {
+                    GraphDecision::Eager => ExecutionMode::Eager,
+                    GraphDecision::Graph(slot) => ExecutionMode::DecodeGraph {
+                        slot: self
+                            .graph
+                            .as_ref()
+                            .and_then(|g| g.slot_size(slot))
+                            .unwrap_or(plan.batch),
+                    },
+                    GraphDecision::PrefillGraph(tokens) => ExecutionMode::PrefillGraph { tokens },
+                },
+                batch: plan.batch,
+                tokens: plan.num_tokens,
+                workspace: WorkspaceUse::Runtime,
+            };
+            execution.execute(
+                &self.execution_metrics.clone(),
+                |execution| match execution.mode {
+                    ExecutionMode::Eager => self.step_eager(&plan, req),
+                    ExecutionMode::DecodeGraph { .. } => {
+                        let GraphDecision::Graph(slot) = decision else {
+                            unreachable!()
+                        };
+                        self.step_graph(slot, &plan, req)
+                    }
+                    ExecutionMode::PrefillGraph { tokens } => {
+                        self.step_prefill_graph(tokens, &plan, req)
+                    }
+                    ExecutionMode::MixedGraph { .. } => unreachable!("ordinary step plan"),
+                },
+            )
         })();
         // A successful forward alone does not make a step committable:
         // finalization, sampling and result validation must succeed too.

--- a/crates/infer-worker/src/application/runtime/mod.rs
+++ b/crates/infer-worker/src/application/runtime/mod.rs
@@ -33,6 +33,8 @@ mod peer;
 mod plan;
 mod recurrent;
 mod startup;
+mod speculative;
+pub use speculative::TargetStep;
 
 pub use graph_exec::{GraphDecision, GraphRunner, GraphSlotId};
 pub use mixed_abc::MixedStepTicket;
@@ -612,26 +614,35 @@ where
 
     fn step_local(&mut self, req: &StepRequest) -> OpResult<StepOutput> {
         let plan = self.build_plan(req)?;
-        self.prepare_recurrent(req, &plan)?;
-        self.upload_index(&plan, req)?;
-        self.prepare_multimodal(req)?;
-        let decision = if self.requires_multimodal_prefill(req)
-            || req.sampling.iter().any(|params| !params.is_greedy())
-        {
-            // Captured decode and mixed ABC graphs include an argmax node and
-            // expose no logits to the sampler. Stochastic requests therefore
-            // use the eager tail, while deterministic traffic retains graphs.
-            GraphDecision::Eager
-        } else {
-            self.decide(&plan)
-        };
-        match decision {
-            GraphDecision::Eager => self.step_eager(&plan, req),
-            GraphDecision::Graph(slot) => self.step_graph(slot, &plan, req),
-            GraphDecision::PrefillGraph(num_tokens) => {
-                self.step_prefill_graph(num_tokens, &plan, req)
-            }
+        if !req.draft_tokens.is_empty() {
+            return self.step_speculative(req, &plan).map(|(output, _)| output);
         }
+        self.prepare_recurrent(req, &plan)?;
+        let result = (|| {
+            self.upload_index(&plan, req)?;
+            self.prepare_multimodal(req)?;
+            let decision = if self.requires_multimodal_prefill(req)
+                || !req.draft_tokens.is_empty()
+                || req.sampling.iter().any(|params| !params.is_greedy())
+            {
+                // Verification needs every target row, including the bonus
+                // row. Even K=0 uses its explicit eager verification contract.
+                // Captured ordinary decode contains an argmax-only tail.
+                GraphDecision::Eager
+            } else {
+                self.decide(&plan)
+            };
+            match decision {
+                GraphDecision::Eager => self.step_eager(&plan, req),
+                GraphDecision::Graph(slot) => self.step_graph(slot, &plan, req),
+                GraphDecision::PrefillGraph(num_tokens) => {
+                    self.step_prefill_graph(num_tokens, &plan, req)
+                }
+            }
+        })();
+        // A successful forward alone does not make a step committable:
+        // finalization, sampling and result validation must succeed too.
+        self.finish_recurrent_step(result)
     }
 
     fn step_eager(
@@ -675,6 +686,8 @@ where
     /// (input ids, hidden, KV pool, KV index) is a fixed allocation, so the
     /// kernel sequence is replayable as a CUDA graph. Under graph capture the
     /// scratch tensors allocated inside the model come from the capture arena.
+    /// This only executes kernels; the enclosing step owns history commit or
+    /// invalidation. Recording a graph must never advance logical history.
     pub(super) fn run_layers(
         &mut self,
         plan: &crate::domain::plan::BatchPlan,
@@ -706,8 +719,7 @@ where
             ),
             None => crate::domain::cache::ModelCacheView::full(&mut self.kv_pool, &self.kv_index),
         };
-        let result = self
-            .model
+        self.model
             .embed(input_ids, &mut hidden, &ctx)
             .and_then(|()| {
                 for item in &self.visual.overrides {
@@ -722,14 +734,10 @@ where
                     &mut cache,
                     &ctx,
                 )
-            });
-        if let Some(state) = &mut self.recurrent {
-            state.complete(result.is_ok());
-        }
-        result
+            })
     }
 
-    /// Finalize (logits) + sample/verify + KV commit. Always eager: the capture
+    /// Finalize (logits) + sample/verify into a retention decision. Always eager: the capture
     /// arena is disabled here, so these allocations use the normal allocator and
     /// the (data-dependent, variable-shape) sampling never enters a graph.
     pub(super) fn sample_tail(
@@ -759,8 +767,8 @@ where
             SampleRows::All
         };
         let logits = self.model.finalize(&hidden, sample_rows, &ctx)?;
-        let sids: Vec<u64> = req.seqs.iter().map(|seq| seq.sequence_id).collect();
-        let (mut tokens, accepted, speculative_len) = if req.draft_tokens.is_empty() {
+        let (mut tokens, mut materialized_tokens, accepted_drafts) = if req.draft_tokens.is_empty()
+        {
             let mut tokens: Vec<Vec<SampledToken>> =
                 if req.sampling.iter().any(|params| !params.is_greedy()) {
                     let sampled = self.sampler.sample(&logits.0, &req.sampling, &ctx)?;
@@ -825,76 +833,57 @@ where
                     tokens
                 };
             tokens.resize_with(plan.batch, Vec::new);
-            let accepted: Vec<u32> = plan.q_lens.iter().map(|&q| q.max(0) as u32).collect();
-            let speculative_len = vec![0; plan.batch];
-            (tokens, accepted, speculative_len)
+            let materialized = plan.q_lens.iter().map(|&q| q as u32).collect();
+            (tokens, materialized, None)
         } else {
-            let draft_tokens = flatten_draft_tokens(req, plan)?;
-            let draft_probs = D::alloc_tensor::<f32>(
-                Shape::from_slice(&[logits.0.numel().max(1)]),
-                logits.0.device(),
+            let decisions = crate::application::speculative::GreedyVerifier.verify(
+                &logits.0,
+                &req.draft_tokens,
+                &req.sampling,
+                &ctx,
             )?;
-            let verify =
-                self.sampler
-                    .verify(&logits.0, &draft_tokens, &draft_probs, &req.sampling, &ctx)?;
-            if verify.accepted_count.len() != plan.batch {
-                return Err(OpError::Shape(format!(
-                    "Runtime::step: verify accepted_count {} != batch {}",
-                    verify.accepted_count.len(),
-                    plan.batch
-                )));
+            let mut tokens = Vec::with_capacity(plan.batch);
+            let mut materialized = Vec::with_capacity(plan.batch);
+            let mut accepted = Vec::with_capacity(plan.batch);
+            for (draft, decision) in req.draft_tokens.iter().zip(decisions) {
+                let n = decision.accepted_drafts;
+                let mut row = Vec::with_capacity(n + 1);
+                row.extend(draft[..n].iter().map(|&token_id| SampledToken {
+                    token_id,
+                    logprob: 0.0,
+                    top_logprobs: Vec::new(),
+                }));
+                row.push(decision.correction_or_bonus);
+                tokens.push(row);
+                // The pending input is retained even when every draft is rejected.
+                materialized.push((n + 1) as u32);
+                accepted.push(n as u32);
             }
-            let speculative_len: Vec<u32> = req
-                .draft_tokens
-                .iter()
-                .map(|tokens| tokens.len() as u32)
-                .collect();
-            for (i, (&accepted, &spec)) in verify
-                .accepted_count
-                .iter()
-                .zip(speculative_len.iter())
-                .enumerate()
-            {
-                if accepted > spec {
-                    return Err(OpError::Shape(format!(
-                        "Runtime::step: seq[{}] accepted {} > spec {}",
-                        i, accepted, spec
-                    )));
-                }
-            }
-            let tokens = spec_tokens(req, &verify.accepted_count, verify.bonus_token)?;
-            for (seq, &spec) in req.seqs.iter().zip(speculative_len.iter()) {
-                if spec > 0 {
-                    self.kv_pool
-                        .seq_kv_len
-                        .insert(seq.sequence_id, seq.kv_len_after as u32);
-                }
-            }
-            (tokens, verify.accepted_count, speculative_len)
+            (tokens, materialized, Some(accepted))
         };
         synchronize_tp_sampled_tokens::<D>(&self.scope, &self.abc.argmax_out_dev, &mut tokens)?;
-        // Non-speculative steps do NOT touch the pool's per-seq length map: the
-        // worker (`ActiveSeq`) owns the length for ordinary decode/prefill, and
-        // `build_plan` trusts the caller-provided `kv_write_start`. Only the
-        // speculative commit maintains `seq_kv_len` (for `KvEdit::truncate`).
-        // This keeps the map empty under normal operation, so out-of-band
-        // eviction (cancel/preempt/drain) can never orphan an entry.
-        if !req.draft_tokens.is_empty() {
-            self.kv_pool
-                .edit()
-                .apply_step(&sids, &accepted, &speculative_len)?;
-        }
-
-        let finished = finished_flags(req, &tokens);
-        for (sid, done) in sids.iter().zip(finished.iter()) {
-            if *done {
-                self.kv_pool.seq_kv_len.remove(sid);
+        let finished = if accepted_drafts.is_some() {
+            let finished = truncate_speculative_output(req, &mut tokens);
+            for (retained, row) in materialized_tokens.iter_mut().zip(&tokens) {
+                // Keep the pending input plus every emitted draft except the
+                // last emitted token. That last token becomes the next pending
+                // input (or terminates the sequence) and needs no retained KV.
+                *retained = row.len() as u32;
             }
-        }
+            finished
+        } else {
+            finished_flags(req, &tokens)
+        };
+
+        // Runtime does not own the caller's KV lease or authoritative sequence
+        // length. In particular, truncating a pool-side map would neither
+        // release provisional slots nor restore recurrent state. Return the
+        // exact retained input prefix for the enclosing decode engine instead.
 
         Ok(StepOutput {
             tokens,
-            accepted,
+            materialized_tokens,
+            accepted_drafts,
             finished,
             hidden_tap: None,
         })
@@ -960,7 +949,6 @@ where
             true,
         );
         let ids = c_view.to_host_vec()?;
-        let sids: Vec<u64> = req.seqs.iter().map(|seq| seq.sequence_id).collect();
         let mut tokens: Vec<Vec<SampledToken>> = ids
             .iter()
             .map(|&token_id| {
@@ -972,16 +960,12 @@ where
             })
             .collect();
         tokens.resize_with(batch, Vec::new);
-        let accepted: Vec<u32> = plan.q_lens.iter().map(|&q| q.max(0) as u32).collect();
+        let materialized_tokens = plan.q_lens.iter().map(|&q| q.max(0) as u32).collect();
         let finished = finished_flags(req, &tokens);
-        for (sid, done) in sids.iter().zip(finished.iter()) {
-            if *done {
-                self.kv_pool.seq_kv_len.remove(sid);
-            }
-        }
         Ok(StepOutput {
             tokens,
-            accepted,
+            materialized_tokens,
+            accepted_drafts: None,
             finished,
             hidden_tap: None,
         })
@@ -1146,70 +1130,31 @@ pub(super) fn u32_to_i32_saturating(x: u32) -> i32 {
     x.min(i32::MAX as u32) as i32
 }
 
-fn flatten_draft_tokens(req: &StepRequest, plan: &BatchPlan) -> OpResult<Vec<i32>> {
-    if req.draft_tokens.len() != plan.batch {
-        return Err(OpError::Shape(format!(
-            "flatten_draft_tokens: draft_tokens {} != batch {}",
-            req.draft_tokens.len(),
-            plan.batch
-        )));
-    }
-    let mut out = Vec::with_capacity(plan.num_tokens);
-    for (i, draft) in req.draft_tokens.iter().enumerate() {
-        let expected = plan.q_lens[i].max(0) as usize;
-        if draft.len() != expected {
-            return Err(OpError::Shape(format!(
-                "flatten_draft_tokens: seq[{}] draft {} != q_len {}",
-                i,
-                draft.len(),
-                expected
-            )));
-        }
-        out.extend_from_slice(draft);
-    }
-    Ok(out)
-}
-
-fn spec_tokens(
-    req: &StepRequest,
-    accepted: &[u32],
-    bonus: Vec<SampledToken>,
-) -> OpResult<Vec<Vec<SampledToken>>> {
-    if accepted.len() != req.seqs.len() || bonus.len() != req.seqs.len() {
-        return Err(OpError::Shape(format!(
-            "spec_tokens: accepted={} bonus={} batch={}",
-            accepted.len(),
-            bonus.len(),
-            req.seqs.len()
-        )));
-    }
-    let mut out = Vec::with_capacity(req.seqs.len());
-    for i in 0..req.seqs.len() {
-        let draft = req
-            .draft_tokens
-            .get(i)
-            .ok_or_else(|| OpError::Shape(format!("spec_tokens: missing draft row {}", i)))?;
-        let n = accepted[i] as usize;
-        if n > draft.len() {
-            return Err(OpError::Shape(format!(
-                "spec_tokens: accepted {} > draft {} for row {}",
-                n,
-                draft.len(),
-                i
-            )));
-        }
-        let mut row = draft[..n]
-            .iter()
-            .map(|&token_id| SampledToken {
-                token_id,
-                logprob: 0.0,
-                top_logprobs: Vec::new(),
-            })
-            .collect::<Vec<_>>();
-        row.push(bonus[i].clone());
-        out.push(row);
-    }
-    Ok(out)
+/// Stop a verified output at its first EOS or remaining generation budget.
+/// Callers derive the retained INPUT prefix from this final output, not from
+/// the untruncated number of matching drafts. An emitted terminal EOS remains
+/// the last (unmaterialized) token just like a correction/bonus token.
+fn truncate_speculative_output(req: &StepRequest, tokens: &mut [Vec<SampledToken>]) -> Vec<bool> {
+    tokens
+        .iter_mut()
+        .enumerate()
+        .map(|(i, row)| {
+            let generated = req.stop.generated_counts.get(i).copied().unwrap_or(0);
+            let max = req.stop.max_tokens.get(i).copied().unwrap_or(u32::MAX);
+            row.truncate(max.saturating_sub(generated) as usize);
+            let ignore_eos = req.stop.ignore_eos.get(i).copied().unwrap_or(false);
+            let eos = (!ignore_eos)
+                .then(|| {
+                    row.iter()
+                        .position(|token| req.stop.eos_ids.contains(&token.token_id))
+                })
+                .flatten();
+            if let Some(index) = eos {
+                row.truncate(index + 1);
+            }
+            eos.is_some() || generated.saturating_add(row.len() as u32) >= max
+        })
+        .collect()
 }
 
 /// Install rank 0's sampled ids on every TP rank before any rank derives stop
@@ -1273,8 +1218,13 @@ pub(super) fn finished_flags(req: &StepRequest, tokens: &[Vec<SampledToken>]) ->
                 && row
                     .iter()
                     .any(|token| req.stop.eos_ids.contains(&token.token_id));
-            let generated =
-                req.stop.generated_counts.get(i).copied().unwrap_or(0) + row.len() as u32;
+            let generated = req
+                .stop
+                .generated_counts
+                .get(i)
+                .copied()
+                .unwrap_or(0)
+                .saturating_add(row.len() as u32);
             let max = req.stop.max_tokens.get(i).copied().unwrap_or(u32::MAX);
             hit_eos || generated >= max
         })
@@ -1683,12 +1633,202 @@ mod tests {
 
         let out = runtime.step(&req).unwrap();
 
-        assert_eq!(out.accepted, vec![1, 1]);
+        assert_eq!(out.materialized_tokens, vec![1, 1]);
+        assert_eq!(out.accepted_drafts, None);
         assert_eq!(out.tokens[0][0].token_id, 1);
         assert_eq!(out.tokens[1][0].token_id, 2);
-        // Non-speculative steps leave the pool's per-seq length map empty
-        // (the worker owns the length); only the speculative path populates it.
+        // The caller owns lengths and leases; the runtime keeps no duplicate
+        // pool-side length, for ordinary or speculative execution.
         assert!(runtime.kv_pool.seq_kv_len.is_empty());
+    }
+
+    fn tiny_runtime() -> Runtime<f32, Cpu, TinyDecoder> {
+        Runtime::new(
+            TinyDecoder::plain(),
+            HostScope::new(Cpu),
+            Box::new(GreedySampler),
+            32,
+            1,
+            32,
+            32,
+            16,
+            4,
+            Vec::new(),
+        )
+        .unwrap()
+    }
+
+    fn verification_request(drafts: &[&[i32]]) -> StepRequest {
+        let mut req = req_for_batch(drafts.len());
+        req.draft_tokens = drafts.iter().map(|draft| draft.to_vec()).collect();
+        for (seq, draft) in req.seqs.iter_mut().zip(drafts) {
+            seq.input_ids = std::iter::once(0).chain(draft.iter().copied()).collect();
+            seq.positions = (0..seq.input_ids.len() as i32).collect();
+            seq.kv_len_after = seq.input_ids.len() as i32;
+            seq.block_table = (0..seq.input_ids.len() as u32).collect();
+        }
+        req
+    }
+
+    #[test]
+    fn verification_keeps_pending_input_and_uses_independent_bonus_row() {
+        for (draft, accepted, expected) in [
+            (vec![0, 2], 0, vec![1]),
+            (vec![1, 0], 1, vec![1, 2]),
+            (vec![1, 2], 2, vec![1, 2, 3]),
+            (vec![], 0, vec![1]),
+        ] {
+            let mut runtime = tiny_runtime();
+            let req = verification_request(&[&draft]);
+            let output = runtime.step(&req).unwrap();
+            let actual: Vec<_> = output.tokens[0].iter().map(|t| t.token_id).collect();
+            assert_eq!(actual, expected);
+            assert_eq!(output.accepted_drafts, Some(vec![accepted]));
+            assert_eq!(output.materialized_tokens, vec![accepted + 1]);
+            assert_eq!(output.finished, vec![false]);
+            assert!(runtime.kv_pool.seq_kv_len.is_empty());
+        }
+    }
+
+    #[test]
+    fn verification_offsets_include_each_sequences_bonus_row() {
+        let mut runtime = tiny_runtime();
+        // TinyDecoder predicts [1,2,3 | 0 | 1,2]. The zero-draft middle
+        // sequence still owns a target row and emits its own correction.
+        let req = verification_request(&[&[1, 2], &[], &[3]]);
+        let output = runtime.step(&req).unwrap();
+        let ids: Vec<Vec<_>> = output
+            .tokens
+            .iter()
+            .map(|row| row.iter().map(|t| t.token_id).collect())
+            .collect();
+        assert_eq!(ids, vec![vec![1, 2, 3], vec![0], vec![1]]);
+        assert_eq!(output.accepted_drafts, Some(vec![2, 0, 0]));
+        assert_eq!(output.materialized_tokens, vec![3, 1, 1]);
+        assert!(runtime.kv_pool.seq_kv_len.is_empty());
+    }
+
+    #[test]
+    fn verification_eos_limits_output_and_retained_input_prefix() {
+        for (eos, expected) in [(1, vec![1]), (2, vec![1, 2]), (3, vec![1, 2, 3])] {
+            let mut runtime = tiny_runtime();
+            let mut req = verification_request(&[&[1, 2]]);
+            req.stop.eos_ids = vec![eos];
+            let output = runtime.step(&req).unwrap();
+            let ids: Vec<_> = output.tokens[0].iter().map(|t| t.token_id).collect();
+            assert_eq!(ids, expected);
+            assert_eq!(output.materialized_tokens, vec![expected.len() as u32]);
+            assert_eq!(output.accepted_drafts, Some(vec![2]));
+            assert_eq!(output.finished, vec![true]);
+        }
+        let mut runtime = tiny_runtime();
+        let mut req = verification_request(&[&[1, 2]]);
+        req.stop.eos_ids = vec![1];
+        req.stop.ignore_eos = vec![true];
+        req.stop.max_tokens = vec![3];
+        let output = runtime.step(&req).unwrap();
+        assert_eq!(output.tokens[0].len(), 3);
+        assert_eq!(output.materialized_tokens, vec![3]);
+        assert_eq!(output.finished, vec![true]);
+    }
+
+    #[test]
+    fn verification_rejects_bad_contracts_before_forward() {
+        let runtime = tiny_runtime();
+        let valid = verification_request(&[&[1, 2]]);
+        let mut bad = valid.clone();
+        bad.draft_tokens[0].push(3);
+        assert!(
+            runtime
+                .build_plan(&bad)
+                .unwrap_err()
+                .to_string()
+                .contains("K+1")
+        );
+        let mut bad = valid.clone();
+        bad.draft_tokens[0][1] = 0;
+        assert!(
+            runtime
+                .build_plan(&bad)
+                .unwrap_err()
+                .to_string()
+                .contains("suffix")
+        );
+        let mut bad = valid.clone();
+        bad.stop.max_tokens[0] = 2;
+        assert!(
+            runtime
+                .build_plan(&bad)
+                .unwrap_err()
+                .to_string()
+                .contains("budget")
+        );
+        let mut bad = valid.clone();
+        bad.sampling[0].temperature = 1.0;
+        assert!(runtime.build_plan(&bad).is_err());
+        let mut bad = valid.clone();
+        bad.seqs[0].input_ids[0] = -1;
+        assert!(
+            runtime
+                .build_plan(&bad)
+                .unwrap_err()
+                .to_string()
+                .contains("vocabulary")
+        );
+        let mut bad = valid;
+        bad.seqs[0].kv_write_start = 31;
+        bad.seqs[0].kv_len_after = 34;
+        assert!(
+            runtime
+                .build_plan(&bad)
+                .unwrap_err()
+                .to_string()
+                .contains("context")
+        );
+    }
+
+    #[test]
+    fn speculative_output_truncation_handles_exhausted_and_overflowing_counts() {
+        let mut req = req_for_batch(2);
+        req.stop.generated_counts = vec![15, u32::MAX];
+        req.stop.max_tokens = vec![16, u32::MAX];
+        let mut rows = vec![vec![tok(1), tok(2)], vec![tok(3)]];
+        assert_eq!(
+            truncate_speculative_output(&req, &mut rows),
+            vec![true, true]
+        );
+        assert_eq!(rows[0].len(), 1);
+        assert!(rows[1].is_empty());
+    }
+
+    #[test]
+    fn run_layers_does_not_commit_recurrent_history() {
+        use crate::domain::cache::{LayerCacheSpec, LinearDims};
+        let mut runtime = tiny_runtime();
+        let layout = CacheLayout::new([LayerCacheSpec::Linear(LinearDims {
+            num_key_heads: 1,
+            num_value_heads: 1,
+            key_head_dim: 1,
+            value_head_dim: 1,
+            conv_kernel_dim: 1,
+        })])
+        .unwrap();
+        runtime.recurrent = Some(recurrent::RecurrentState::new(&layout, 4, &Cpu).unwrap());
+        let req = req_for_batch(1);
+        let plan = runtime.build_plan(&req).unwrap();
+        runtime.prepare_recurrent(&req, &plan).unwrap();
+        runtime.upload_index(&plan, &req).unwrap();
+        let ids = runtime.input_ids_tensor(&req, &plan).unwrap();
+        runtime.run_layers(&plan, &ids).unwrap();
+        let mut next = req.clone();
+        next.seqs[0].kv_write_start = 1;
+        next.seqs[0].kv_len_after = 2;
+        next.seqs[0].positions = vec![1];
+        let next_plan = runtime.build_plan(&next).unwrap();
+        assert!(runtime.prepare_recurrent(&next, &next_plan).is_err());
+        runtime.finish_recurrent_step(Ok(())).unwrap();
+        runtime.prepare_recurrent(&next, &next_plan).unwrap();
+        runtime.finish_recurrent_step(Ok(())).unwrap();
     }
 
     #[test]

--- a/crates/infer-worker/src/application/runtime/mod.rs
+++ b/crates/infer-worker/src/application/runtime/mod.rs
@@ -32,8 +32,8 @@ mod multimodal;
 mod peer;
 mod plan;
 mod recurrent;
-mod startup;
 mod speculative;
+mod startup;
 pub use speculative::TargetStep;
 
 pub use graph_exec::{GraphDecision, GraphRunner, GraphSlotId};

--- a/crates/infer-worker/src/application/runtime/mod.rs
+++ b/crates/infer-worker/src/application/runtime/mod.rs
@@ -53,6 +53,7 @@ where
 {
     pub model: M,
     recurrent: Option<recurrent::RecurrentState<T, D>>,
+    retained_request: Option<StepRequest>,
     visual: multimodal::VisualState<T, D>,
     pub kv_pool: PagedKvPool<T, D>,
     pub kv_index: KvIndexTensors<D>,
@@ -492,6 +493,7 @@ where
 
         Ok(Self {
             recurrent,
+            retained_request: None,
             visual: multimodal::VisualState::default(),
             model,
             kv_pool,
@@ -836,11 +838,13 @@ where
             let materialized = plan.q_lens.iter().map(|&q| q as u32).collect();
             (tokens, materialized, None)
         } else {
-            let decisions = crate::application::speculative::GreedyVerifier.verify(
+            let decisions = crate::application::speculative::GreedyVerifier.verify_into(
                 &logits.0,
                 &req.draft_tokens,
                 &req.sampling,
                 &ctx,
+                &mut self.abc.argmax_out_dev.narrow(0, 0, plan.num_tokens)?,
+                &self.abc.argmax_ws,
             )?;
             let mut tokens = Vec::with_capacity(plan.batch);
             let mut materialized = Vec::with_capacity(plan.batch);

--- a/crates/infer-worker/src/application/runtime/mod.rs
+++ b/crates/infer-worker/src/application/runtime/mod.rs
@@ -652,6 +652,15 @@ where
         plan: &crate::domain::plan::BatchPlan,
         req: &StepRequest,
     ) -> OpResult<StepOutput> {
+        self.step_eager_with_input(plan, req, None)
+    }
+
+    fn step_eager_with_input(
+        &mut self,
+        plan: &BatchPlan,
+        req: &StepRequest,
+        device_input: Option<&Tensor<i32, D>>,
+    ) -> OpResult<StepOutput> {
         // Eager prefill (num_tokens > batch) routes bf16 GEMMs to the build-free
         // chunked path so each distinct prompt length skips the cuBLASLt cache
         // build (~9-18ms off TTFT). A guard restores the default on any return so
@@ -661,7 +670,10 @@ where
             D::set_prefill_gemm_mode(true);
         }
         let _gemm_guard = PrefillGemmGuard::<D>(prefill_gemm, std::marker::PhantomData);
-        let input_ids = self.input_ids_tensor(req, plan)?;
+        let input_ids = match device_input {
+            Some(input) => input.clone(),
+            None => self.input_ids_tensor(req, plan)?,
+        };
         let _trace = std::env::var_os("RUSTINFER_TTFT_TRACE").is_some();
         let _t0 = std::time::Instant::now();
         self.run_layers(plan, &input_ids)?;
@@ -1492,6 +1504,29 @@ mod tests {
         }
     }
 
+    impl crate::domain::model::DecoderReadout<f32, Cpu> for TinyDecoder {
+        fn normalize_hidden_into(
+            &self,
+            hidden: &Hidden<f32, Cpu>,
+            output: &mut Tensor<f32, Cpu>,
+            _ctx: &StepCtx<'_, Cpu>,
+        ) -> OpResult<()> {
+            output.copy_from(&hidden.stream)
+        }
+        fn project_logits_into(
+            &self,
+            normalized: &Tensor<f32, Cpu>,
+            output: &mut Tensor<f32, Cpu>,
+            ctx: &StepCtx<'_, Cpu>,
+        ) -> OpResult<()> {
+            let hidden = Hidden {
+                stream: normalized.clone(),
+                pending: None,
+            };
+            output.copy_from(&self.finalize(&hidden, SampleRows::All, ctx)?.0)
+        }
+    }
+
     fn tok(token_id: i32) -> SampledToken {
         SampledToken {
             token_id,
@@ -1692,6 +1727,80 @@ mod tests {
             assert_eq!(output.finished, vec![false]);
             assert!(runtime.kv_pool.seq_kv_len.is_empty());
         }
+    }
+
+    #[test]
+    fn device_tape_verification_and_replay_skip_host_input_staging() {
+        for draft in [vec![], vec![0, 2], vec![1, 0], vec![1, 2]] {
+            for stop_at_first in [false, true] {
+                let mut direct = tiny_runtime();
+                let mut reference = tiny_runtime();
+                let mut req = verification_request(&[&draft]);
+                if stop_at_first {
+                    req.stop.eos_ids = vec![1];
+                }
+                let tape = Tensor::from_host_slice(&req.seqs[0].input_ids, [draft.len() + 1], &Cpu)
+                    .unwrap();
+                direct.prefill_ids_host.fill(-7);
+                direct
+                    .prefill_ids_buf
+                    .upload_from_host(&vec![-7; direct.prefill_ids_buf.numel()])
+                    .unwrap();
+                let mut hidden = Tensor::zeros([draft.len() + 1, 1], &Cpu).unwrap();
+                let out = direct
+                    .step_with_hidden_input(&req, &mut hidden, Some(&tape))
+                    .unwrap();
+                let expected = reference.step_with_hidden(&req).unwrap();
+                assert_eq!(out.accepted_drafts, expected.output.accepted_drafts);
+                assert_eq!(out.materialized_tokens, expected.output.materialized_tokens);
+                assert_eq!(out.finished, expected.output.finished);
+                assert_eq!(
+                    out.tokens[0].iter().map(|t| t.token_id).collect::<Vec<_>>(),
+                    expected.output.tokens[0]
+                        .iter()
+                        .map(|t| t.token_id)
+                        .collect::<Vec<_>>()
+                );
+                assert_eq!(
+                    hidden
+                        .narrow(0, 0, out.materialized_tokens[0] as usize)
+                        .unwrap()
+                        .to_host_vec()
+                        .unwrap(),
+                    expected.normalized_hidden.to_host_vec().unwrap()
+                );
+                assert!(direct.prefill_ids_host.iter().all(|&x| x == -7));
+                assert!(
+                    direct
+                        .prefill_ids_buf
+                        .to_host_vec()
+                        .unwrap()
+                        .iter()
+                        .all(|&x| x == -7)
+                );
+                assert_eq!(tape.to_host_vec().unwrap(), req.seqs[0].input_ids);
+            }
+        }
+    }
+
+    #[test]
+    fn device_tape_rejects_bad_shape_and_multi_sequence_before_execution() {
+        let mut runtime = tiny_runtime();
+        let mut hidden = Tensor::zeros([8, 1], &Cpu).unwrap();
+        let req = verification_request(&[&[1, 2]]);
+        let short = Tensor::from_host_slice(&[0, 1], [2], &Cpu).unwrap();
+        assert!(
+            runtime
+                .step_with_hidden_input(&req, &mut hidden, Some(&short))
+                .is_err()
+        );
+        let multi = verification_request(&[&[], &[]]);
+        assert!(
+            runtime
+                .step_with_hidden_input(&multi, &mut hidden, Some(&short))
+                .is_err()
+        );
+        assert!(runtime.step_with_hidden(&req).is_ok());
     }
 
     #[test]

--- a/crates/infer-worker/src/application/runtime/plan.rs
+++ b/crates/infer-worker/src/application/runtime/plan.rs
@@ -59,7 +59,15 @@ where
                     self.max_blocks_per_seq
                 )));
             }
-            total_tokens += seq.input_ids.len();
+            total_tokens = total_tokens
+                .checked_add(seq.input_ids.len())
+                .ok_or_else(|| OpError::Shape("Runtime::step: token count overflow".into()))?;
+            if total_tokens > self.cap_num_tokens || seq.input_ids.len() > i32::MAX as usize {
+                return Err(OpError::Shape(format!(
+                    "Runtime::step: token count {total_tokens} exceeds capacity {}",
+                    self.cap_num_tokens
+                )));
+            }
             q_lens.push(seq.input_ids.len() as i32);
             if seq.kv_write_start < 0 || seq.kv_len_after < 0 {
                 return Err(OpError::Shape(format!(
@@ -93,6 +101,12 @@ where
                     seq.input_ids.len()
                 )));
             }
+            if expected_after as usize > self.max_seq_len {
+                return Err(OpError::Shape(format!(
+                    "Runtime::step: seq[{i}] context length {expected_after} exceeds max {}",
+                    self.max_seq_len
+                )));
+            }
             kv_lens.push(expected_after as i32);
             seq_positions.push(start as i32);
             if seq.input_ids.len() == 1
@@ -124,15 +138,37 @@ where
                 )));
             }
             for (i, (draft, seq)) in req.draft_tokens.iter().zip(req.seqs.iter()).enumerate() {
-                if draft.len() != seq.input_ids.len() {
+                if draft.len().checked_add(1) != Some(seq.input_ids.len()) {
                     return Err(OpError::Shape(format!(
-                        "Runtime::step: seq[{}] draft_tokens {} != input_ids {}",
+                        "Runtime::step: seq[{}] requires K+1 inputs for {} drafts, got {}",
                         i,
                         draft.len(),
                         seq.input_ids.len()
                     )));
                 }
+                if seq.input_ids[1..] != draft[..] {
+                    return Err(OpError::Shape(format!(
+                        "Runtime::step: seq[{i}] verification input suffix differs from drafts"
+                    )));
+                }
+                if seq
+                    .input_ids
+                    .iter()
+                    .any(|&id| id < 0 || id as usize >= self.dims.vocab_size)
+                {
+                    return Err(OpError::Shape(format!(
+                        "Runtime::step: seq[{i}] verification token outside vocabulary"
+                    )));
+                }
+                let generated = req.stop.generated_counts.get(i).copied().unwrap_or(0);
+                let max = req.stop.max_tokens.get(i).copied().unwrap_or(u32::MAX);
+                if seq.input_ids.len() > max.saturating_sub(generated) as usize {
+                    return Err(OpError::Shape(format!(
+                        "Runtime::step: seq[{i}] verification width exceeds remaining output budget"
+                    )));
+                }
             }
+            crate::application::speculative::validate_sampling(&req.sampling, batch)?;
         }
 
         // `total_q_tiles` is the only thing the plan needs from the ragged-tile

--- a/crates/infer-worker/src/application/runtime/recurrent.rs
+++ b/crates/infer-worker/src/application/runtime/recurrent.rs
@@ -14,27 +14,36 @@ pub(super) struct RecurrentState<T: Dtype, D: LlmBackend> {
     /// failure cannot leave reusable, partially executed recurrent history.
     decode_in_flight: Vec<u64>,
     capacity: usize,
+    pub(super) verification_snapshot: Option<crate::domain::cache::LinearSnapshot<T, D>>,
+    snapshot_slots: Vec<usize>,
 }
 
 impl<T: Dtype, D: LlmBackend> RecurrentState<T, D> {
-    pub(super) fn snapshot(
-        &self,
-        req: &StepRequest,
-    ) -> OpResult<crate::domain::cache::LinearSnapshot<T, D>> {
-        let slots = req
-            .seqs
-            .iter()
-            .map(|s| self.slots[&s.sequence_id].0)
-            .collect::<Vec<_>>();
-        crate::domain::cache::LinearSnapshot::capture(&self.layers, &slots)
+    pub(super) fn prepare_snapshot(&mut self) -> OpResult<()> {
+        if self.verification_snapshot.is_none() {
+            self.verification_snapshot = Some(crate::domain::cache::LinearSnapshot::reserve(
+                &self.layers,
+                self.capacity,
+            )?);
+        }
+        Ok(())
+    }
+    pub(super) fn snapshot(&mut self, req: &StepRequest, scope: &D::Scope) -> OpResult<()> {
+        self.prepare_snapshot()?;
+        self.snapshot_slots.clear();
+        self.snapshot_slots
+            .extend(req.seqs.iter().map(|s| self.slots[&s.sequence_id].0));
+        self.verification_snapshot.as_mut().unwrap().capture_on(
+            &self.layers,
+            &self.snapshot_slots,
+            scope,
+        )
     }
 
     pub(super) fn retain_step(&mut self, req: &StepRequest) {
-        self.step = req
-            .seqs
-            .iter()
-            .map(|s| (s.sequence_id, s.kv_len_after))
-            .collect();
+        self.step.clear();
+        self.step
+            .extend(req.seqs.iter().map(|s| (s.sequence_id, s.kv_len_after)));
     }
 
     pub(super) fn has_decode_in_flight(&self) -> bool {
@@ -58,7 +67,9 @@ impl<T: Dtype, D: LlmBackend> RecurrentState<T, D> {
             batch: None,
             slots: HashMap::new(),
             free: (0..capacity).rev().collect(),
-            step: Vec::new(),
+            step: Vec::with_capacity(capacity),
+            verification_snapshot: None,
+            snapshot_slots: Vec::with_capacity(capacity),
             decode_in_flight: Vec::with_capacity(capacity),
             capacity,
         })
@@ -69,7 +80,7 @@ impl<T: Dtype, D: LlmBackend> RecurrentState<T, D> {
         }
     }
     pub fn complete(&mut self, success: bool) {
-        for (id, len) in std::mem::take(&mut self.step) {
+        while let Some((id, len)) = self.step.pop() {
             if success {
                 if let Some(entry) = self.slots.get_mut(&id) {
                     entry.1 = len;

--- a/crates/infer-worker/src/application/runtime/recurrent.rs
+++ b/crates/infer-worker/src/application/runtime/recurrent.rs
@@ -9,10 +9,37 @@ pub(super) struct RecurrentState<T: Dtype, D: LlmBackend> {
     slots: HashMap<u64, (usize, i32)>,
     free: Vec<usize>,
     step: Vec<(u64, i32)>,
+    /// Ordinary decode issues advance logical history before their async
+    /// output is collected. Retain their owners until collection so a late
+    /// failure cannot leave reusable, partially executed recurrent history.
+    decode_in_flight: Vec<u64>,
     capacity: usize,
 }
 
 impl<T: Dtype, D: LlmBackend> RecurrentState<T, D> {
+    pub(super) fn snapshot(
+        &self,
+        req: &StepRequest,
+    ) -> OpResult<crate::domain::cache::LinearSnapshot<T, D>> {
+        let slots = req
+            .seqs
+            .iter()
+            .map(|s| self.slots[&s.sequence_id].0)
+            .collect::<Vec<_>>();
+        crate::domain::cache::LinearSnapshot::capture(&self.layers, &slots)
+    }
+
+    pub(super) fn retain_step(&mut self, req: &StepRequest) {
+        self.step = req
+            .seqs
+            .iter()
+            .map(|s| (s.sequence_id, s.kv_len_after))
+            .collect();
+    }
+
+    pub(super) fn has_decode_in_flight(&self) -> bool {
+        !self.decode_in_flight.is_empty()
+    }
     pub fn has_live_sequences(&self) -> bool {
         !self.slots.is_empty()
     }
@@ -32,6 +59,7 @@ impl<T: Dtype, D: LlmBackend> RecurrentState<T, D> {
             slots: HashMap::new(),
             free: (0..capacity).rev().collect(),
             step: Vec::new(),
+            decode_in_flight: Vec::with_capacity(capacity),
             capacity,
         })
     }
@@ -53,11 +81,37 @@ impl<T: Dtype, D: LlmBackend> RecurrentState<T, D> {
             }
         }
     }
+
+    pub fn record_decode_issue(&mut self, req: &StepRequest) {
+        self.decode_in_flight.clear();
+        self.decode_in_flight
+            .extend(req.seqs.iter().map(|seq| seq.sequence_id));
+    }
+
+    pub fn collect_decode(&mut self, success: bool) {
+        while let Some(id) = self.decode_in_flight.pop() {
+            if !success {
+                self.release(id);
+            }
+        }
+    }
 }
 
 impl<T: Dtype, D: LlmBackend, M: DecoderModel<T, D>> Runtime<T, D, M> {
     pub fn has_recurrent_state(&self) -> bool {
         self.recurrent.is_some()
+    }
+
+    /// Resolve an already prepared ordinary step at its execution boundary.
+    /// Synchronous steps call this after sampling; ABC calls it after the
+    /// entire issue has been enqueued. The latter advances logical history
+    /// for ordered, overlapping execution, not a claim of GPU completion.
+    /// Capture/forward helpers never commit history themselves.
+    pub(super) fn finish_recurrent_step<R>(&mut self, result: OpResult<R>) -> OpResult<R> {
+        if let Some(state) = &mut self.recurrent {
+            state.complete(result.is_ok());
+        }
+        result
     }
 
     /// Call after completion, cancellation, or preemption. Reuse zeroes the slot.
@@ -90,15 +144,25 @@ impl<T: Dtype, D: LlmBackend, M: DecoderModel<T, D>> Runtime<T, D, M> {
         req: &StepRequest,
         plan: &BatchPlan,
     ) -> OpResult<()> {
+        if !req.draft_tokens.is_empty() {
+            return Err(OpError::unsupported(
+                "recurrent execution",
+                "verification outside a snapshot transaction",
+            ));
+        }
+        self.prepare_recurrent_verification(req, plan)
+    }
+
+    /// The speculative caller must snapshot before execution and resolve the
+    /// retained prefix before completing this prepared history.
+    pub(super) fn prepare_recurrent_verification(
+        &mut self,
+        req: &StepRequest,
+        plan: &BatchPlan,
+    ) -> OpResult<()> {
         let Some(state) = &mut self.recurrent else {
             return Ok(());
         };
-        if !req.draft_tokens.is_empty() {
-            return Err(OpError::unsupported(
-                "linear attention",
-                "speculative execution",
-            ));
-        }
         let mut seen = HashSet::new();
         let mut needed = 0;
         // Validate the entire batch before resetting or assigning any state.
@@ -162,5 +226,100 @@ impl<T: Dtype, D: LlmBackend, M: DecoderModel<T, D>> Runtime<T, D, M> {
             state.complete(false);
         }
         result
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::domain::cache::CacheLayout;
+    use crate::domain::plan::StopCriteria;
+    use crate::infrastructure::cpu::Cpu;
+
+    fn state_with_history() -> RecurrentState<f32, Cpu> {
+        let mut state = RecurrentState::new(&CacheLayout::default(), 3, &Cpu).unwrap();
+        state.slots.insert(10, (0, 4));
+        state.slots.insert(20, (1, 7));
+        state.free = vec![2];
+        state
+    }
+
+    fn decode_request(id: u64) -> StepRequest {
+        StepRequest {
+            seqs: vec![SeqStep {
+                sequence_id: id,
+                input_ids: vec![1],
+                positions: vec![4],
+                kv_write_start: 4,
+                kv_len_after: 5,
+                block_table: vec![],
+            }],
+            sampling: vec![],
+            stop: StopCriteria {
+                eos_ids: vec![],
+                generated_counts: vec![],
+                max_tokens: vec![],
+                ignore_eos: vec![],
+            },
+            draft_tokens: vec![],
+        }
+    }
+
+    #[test]
+    fn prepared_history_advances_only_at_explicit_completion() {
+        let mut state = state_with_history();
+        state.step.push((10, 5));
+        assert_eq!(state.slots[&10].1, 4);
+        state.complete(true);
+        assert_eq!(state.slots[&10].1, 5);
+        assert_eq!(state.slots[&20].1, 7);
+        // A capture or repeated completion cannot advance the request twice.
+        state.complete(true);
+        assert_eq!(state.slots[&10].1, 5);
+    }
+
+    #[test]
+    fn failed_prepared_step_invalidates_only_its_requests() {
+        let mut state = state_with_history();
+        state.step.push((10, 5));
+        state.complete(false);
+        assert!(!state.slots.contains_key(&10));
+        assert_eq!(state.slots[&20].1, 7);
+        assert_eq!(state.free.len(), 2);
+        state.complete(false);
+        assert_eq!(state.free.len(), 2);
+    }
+
+    #[test]
+    fn failed_decode_collection_invalidates_overlapped_history() {
+        let mut state = state_with_history();
+        state.step.push((10, 5));
+        state.complete(true);
+        state.record_decode_issue(&decode_request(10));
+        // Mixed issue can advance the same request before decode collection.
+        state.step.extend([(10, 6), (20, 8)]);
+        state.complete(true);
+        state.collect_decode(false);
+        assert!(!state.slots.contains_key(&10));
+        assert_eq!(state.slots[&20].1, 8);
+        assert!(state.decode_in_flight.is_empty());
+        state.collect_decode(false);
+        assert_eq!(state.free.len(), 2);
+    }
+
+    #[test]
+    fn successful_decode_collection_preserves_newer_mixed_progress() {
+        let mut state = state_with_history();
+        let retained_capacity = state.decode_in_flight.capacity();
+        state.step.push((10, 5));
+        state.complete(true);
+        state.record_decode_issue(&decode_request(10));
+        state.step.extend([(10, 6), (20, 8)]);
+        state.complete(true);
+        state.collect_decode(true);
+        assert_eq!(state.slots[&10].1, 6);
+        assert_eq!(state.slots[&20].1, 8);
+        assert!(state.decode_in_flight.is_empty());
+        assert_eq!(state.decode_in_flight.capacity(), retained_capacity);
     }
 }

--- a/crates/infer-worker/src/application/runtime/speculative.rs
+++ b/crates/infer-worker/src/application/runtime/speculative.rs
@@ -74,6 +74,15 @@ impl<T: Dtype, D: LlmBackend, M: DecoderModel<T, D>> Runtime<T, D, M> {
         req: &StepRequest,
         plan: &BatchPlan,
     ) -> OpResult<(StepOutput, BatchPlan)> {
+        self.step_speculative_with_input(req, plan, None)
+    }
+
+    fn step_speculative_with_input(
+        &mut self,
+        req: &StepRequest,
+        plan: &BatchPlan,
+        device_input: Option<&Tensor<i32, D>>,
+    ) -> OpResult<(StepOutput, BatchPlan)> {
         self.validate_eager_transaction(req)?;
         self.prepare_recurrent_verification(req, plan)?;
         let mut retained = self.retained_request.take().unwrap_or_else(|| {
@@ -85,7 +94,7 @@ impl<T: Dtype, D: LlmBackend, M: DecoderModel<T, D>> Runtime<T, D, M> {
             }
             self.upload_index(plan, req)?;
             self.prepare_multimodal(req)?;
-            let output = self.step_eager(plan, req)?;
+            let output = self.step_eager_with_input(plan, req, device_input)?;
             if output.materialized_tokens.len() != req.seqs.len()
                 || req
                     .seqs
@@ -114,7 +123,13 @@ impl<T: Dtype, D: LlmBackend, M: DecoderModel<T, D>> Runtime<T, D, M> {
                     self.prepare_recurrent(&retained, &retained_plan)?;
                 }
                 self.upload_index(&retained_plan, &retained)?;
-                let input = self.input_ids_tensor(&retained, &retained_plan)?;
+                let input = match device_input {
+                    // The direct path is single-sequence, so its retained tape
+                    // is a contiguous prefix. Multi-sequence repacking stays on
+                    // the ordinary host-input path.
+                    Some(input) => input.narrow(0, 0, retained_plan.num_tokens)?,
+                    None => self.input_ids_tensor(&retained, &retained_plan)?,
+                };
                 self.run_layers(&retained_plan, &input)?;
             }
             if let Some(state) = &mut self.recurrent {
@@ -152,8 +167,32 @@ impl<T: Dtype, D: LlmBackend, M: DecoderReadout<T, D>> Runtime<T, D, M> {
         req: &StepRequest,
         normalized_hidden: &mut Tensor<T, D>,
     ) -> OpResult<StepOutput> {
+        self.step_with_hidden_input(req, normalized_hidden, None)
+    }
+
+    /// Internal paired-input path. The serving adapter supplies the host IDs
+    /// and device tape from the same completed proposer call. Keep the tape
+    /// alive and unchanged until this synchronous transaction returns.
+    pub(crate) fn step_with_hidden_input(
+        &mut self,
+        req: &StepRequest,
+        normalized_hidden: &mut Tensor<T, D>,
+        device_input: Option<&Tensor<i32, D>>,
+    ) -> OpResult<StepOutput> {
         let plan = self.build_plan(req)?;
         self.validate_eager_transaction(req)?;
+        if let Some(input) = device_input
+            && (req.seqs.len() != 1
+                || req.draft_tokens.is_empty()
+                || input.shape().as_slice() != [plan.num_tokens]
+                || !input.is_contiguous()
+                || infer_core::device::Device::device_id(input.device())
+                    != infer_core::device::Device::device_id(self.scope.device()))
+        {
+            return Err(OpError::Shape(
+                "invalid speculative device token tape".into(),
+            ));
+        }
         if normalized_hidden.shape().len() != 2
             || normalized_hidden.shape()[0] < plan.num_tokens
             || normalized_hidden.shape()[1] != self.dims.dim
@@ -174,7 +213,7 @@ impl<T: Dtype, D: LlmBackend, M: DecoderReadout<T, D>> Runtime<T, D, M> {
             })();
             (self.finish_recurrent_step(result)?, plan)
         } else {
-            self.step_speculative(req, &plan)?
+            self.step_speculative_with_input(req, &plan, device_input)?
         };
         let result = (|| {
             let n = retained_plan.num_tokens;

--- a/crates/infer-worker/src/application/runtime/speculative.rs
+++ b/crates/infer-worker/src/application/runtime/speculative.rs
@@ -1,0 +1,157 @@
+//! Eager verification transactions and caller-owned target hidden readout.
+use super::*;
+use crate::domain::model::DecoderReadout;
+
+/// Hidden rows correspond to the retained input prefix of each request, packed
+/// in request order. Speculative suffix rows are never exposed as committed.
+pub struct TargetStep<T: Dtype, D: LlmBackend> {
+    pub output: StepOutput,
+    pub normalized_hidden: Tensor<T, D>,
+}
+
+impl<T: Dtype, D: LlmBackend, M: DecoderModel<T, D>> Runtime<T, D, M> {
+    fn validate_eager_transaction(&self, req: &StepRequest) -> OpResult<()> {
+        if self.scope.topology().tp.size != 1 {
+            return Err(OpError::unsupported("target readout", "tensor parallelism"));
+        }
+        if self
+            .recurrent
+            .as_ref()
+            .is_some_and(|r| r.has_decode_in_flight())
+        {
+            return Err(OpError::Shape(
+                "collect in-flight decode before speculative execution".into(),
+            ));
+        }
+        if self.requires_multimodal_prefill(req)
+            || req.seqs.iter().any(|s| {
+                self.multimodal_decode_position(s.sequence_id, s.kv_write_start.max(0) as usize)
+                    .is_some()
+            })
+        {
+            return Err(OpError::unsupported(
+                "speculative execution",
+                "multimodal input",
+            ));
+        }
+        for seq in &req.seqs {
+            if seq
+                .positions
+                .iter()
+                .enumerate()
+                .any(|(i, &p)| seq.kv_write_start.checked_add(i as i32) != Some(p))
+                || seq
+                    .input_ids
+                    .iter()
+                    .any(|&id| id < 0 || id as usize >= self.dims.vocab_size)
+            {
+                return Err(OpError::Shape(
+                    "speculative execution requires valid tokens and consecutive text positions"
+                        .into(),
+                ));
+            }
+        }
+        Ok(())
+    }
+
+    pub(super) fn step_speculative(
+        &mut self,
+        req: &StepRequest,
+        plan: &BatchPlan,
+    ) -> OpResult<(StepOutput, BatchPlan)> {
+        self.validate_eager_transaction(req)?;
+        self.prepare_recurrent_verification(req, plan)?;
+        let result = (|| {
+            self.scope.synchronize()?;
+            let snapshot = self
+                .recurrent
+                .as_ref()
+                .map(|r| r.snapshot(req))
+                .transpose()?;
+            infer_core::device::MemoryPort::synchronize(self.scope.device())?;
+            self.upload_index(plan, req)?;
+            self.prepare_multimodal(req)?;
+            let output = self.step_eager(plan, req)?;
+            let mut retained = req.clone();
+            retained.draft_tokens.clear();
+            for (seq, &n) in retained.seqs.iter_mut().zip(&output.materialized_tokens) {
+                let n = n as usize;
+                if n == 0 || n > seq.input_ids.len() {
+                    return Err(OpError::Shape(
+                        "invalid speculative retention length".into(),
+                    ));
+                }
+                seq.input_ids.truncate(n);
+                seq.positions.truncate(n);
+                seq.kv_len_after = seq.kv_write_start + n as i32;
+            }
+            let retained_plan = self.build_plan(&retained)?;
+            if retained_plan.num_tokens != plan.num_tokens {
+                // GDN has already consumed rejected inputs. Restore the entire
+                // participating batch, then replay just its retained prefixes.
+                // Full-attention KV suffix bytes become inaccessible via lengths;
+                // the lease owner may release the corresponding blocks.
+                self.scope.synchronize()?;
+                if let (Some(saved), Some(state)) = (snapshot.as_ref(), self.recurrent.as_mut()) {
+                    saved.restore(&mut state.layers)?;
+                    infer_core::device::MemoryPort::synchronize(self.scope.device())?;
+                    // Logical lengths still refer to the pre-verification prefix.
+                    self.prepare_recurrent(&retained, &retained_plan)?;
+                }
+                self.upload_index(&retained_plan, &retained)?;
+                let input = self.input_ids_tensor(&retained, &retained_plan)?;
+                self.run_layers(&retained_plan, &input)?;
+            }
+            if let Some(state) = &mut self.recurrent {
+                state.retain_step(&retained);
+            }
+            // No request may observe committed state until replay completes.
+            self.scope.synchronize()?;
+            Ok((output, retained_plan))
+        })();
+        self.finish_recurrent_step(result)
+    }
+}
+
+impl<T: Dtype, D: LlmBackend, M: DecoderReadout<T, D>> Runtime<T, D, M> {
+    /// Explicit text-only, TP=1 eager entry point for a hidden-conditioned
+    /// proposer. Output storage survives later forwards. On an execution error,
+    /// callers must release their KV lease and rebuild the sequence from zero.
+    pub fn step_with_hidden(&mut self, req: &StepRequest) -> OpResult<TargetStep<T, D>> {
+        let plan = self.build_plan(req)?;
+        self.validate_eager_transaction(req)?;
+        let (output, retained_plan) = if req.draft_tokens.is_empty() {
+            self.prepare_recurrent(req, &plan)?;
+            let result = (|| {
+                self.upload_index(&plan, req)?;
+                self.prepare_multimodal(req)?;
+                self.step_eager(&plan, req)
+            })();
+            (self.finish_recurrent_step(result)?, plan)
+        } else {
+            self.step_speculative(req, &plan)?
+        };
+        let result = (|| {
+            let n = retained_plan.num_tokens;
+            let mut normalized_hidden = Tensor::zeros([n, self.dims.dim], self.scope.device())?;
+            let hidden = Hidden {
+                stream: self.hidden.stream.narrow(0, 0, n)?,
+                pending: None,
+            };
+            let ctx = crate::domain::exec::StepCtx::new(&self.scope, &retained_plan);
+            self.model
+                .normalize_hidden_into(&hidden, &mut normalized_hidden, &ctx)?;
+            self.scope.synchronize()?;
+            Ok(TargetStep {
+                output,
+                normalized_hidden,
+            })
+        })();
+        if result.is_err() {
+            for seq in &req.seqs {
+                self.release_sequence(seq.sequence_id);
+            }
+        }
+        result
+    }
+}

--- a/crates/infer-worker/src/application/runtime/speculative.rs
+++ b/crates/infer-worker/src/application/runtime/speculative.rs
@@ -10,6 +10,21 @@ pub struct TargetStep<T: Dtype, D: LlmBackend> {
 }
 
 impl<T: Dtype, D: LlmBackend, M: DecoderModel<T, D>> Runtime<T, D, M> {
+    /// Called by speculative serving/session constructors before requests.
+    pub fn prepare_speculative(&mut self) -> OpResult<()> {
+        if self.retained_request.is_none() {
+            self.retained_request = Some(StepRequest::workspace(
+                self.cap_batch,
+                self.cap_num_tokens,
+                self.max_blocks_per_seq,
+            ));
+        }
+        if let Some(state) = self.recurrent.as_mut() {
+            state.prepare_snapshot()?;
+        }
+        Ok(())
+    }
+
     fn validate_eager_transaction(&self, req: &StepRequest) -> OpResult<()> {
         if self.scope.topology().tp.size != 1 {
             return Err(OpError::unsupported("target readout", "tensor parallelism"));
@@ -61,40 +76,40 @@ impl<T: Dtype, D: LlmBackend, M: DecoderModel<T, D>> Runtime<T, D, M> {
     ) -> OpResult<(StepOutput, BatchPlan)> {
         self.validate_eager_transaction(req)?;
         self.prepare_recurrent_verification(req, plan)?;
+        let mut retained = self.retained_request.take().unwrap_or_else(|| {
+            StepRequest::workspace(self.cap_batch, self.cap_num_tokens, self.max_blocks_per_seq)
+        });
         let result = (|| {
-            self.scope.synchronize()?;
-            let snapshot = self
-                .recurrent
-                .as_ref()
-                .map(|r| r.snapshot(req))
-                .transpose()?;
-            infer_core::device::MemoryPort::synchronize(self.scope.device())?;
+            if let Some(state) = self.recurrent.as_mut() {
+                state.snapshot(req, &self.scope)?;
+            }
             self.upload_index(plan, req)?;
             self.prepare_multimodal(req)?;
             let output = self.step_eager(plan, req)?;
-            let mut retained = req.clone();
-            retained.draft_tokens.clear();
-            for (seq, &n) in retained.seqs.iter_mut().zip(&output.materialized_tokens) {
-                let n = n as usize;
-                if n == 0 || n > seq.input_ids.len() {
-                    return Err(OpError::Shape(
-                        "invalid speculative retention length".into(),
-                    ));
-                }
-                seq.input_ids.truncate(n);
-                seq.positions.truncate(n);
-                seq.kv_len_after = seq.kv_write_start + n as i32;
+            if output.materialized_tokens.len() != req.seqs.len()
+                || req
+                    .seqs
+                    .iter()
+                    .zip(&output.materialized_tokens)
+                    .any(|(seq, &n)| n == 0 || n as usize > seq.input_ids.len())
+            {
+                return Err(OpError::Shape(
+                    "invalid speculative retention length".into(),
+                ));
             }
+            retained.retain_from(req, &output.materialized_tokens);
             let retained_plan = self.build_plan(&retained)?;
             if retained_plan.num_tokens != plan.num_tokens {
                 // GDN has already consumed rejected inputs. Restore the entire
                 // participating batch, then replay just its retained prefixes.
                 // Full-attention KV suffix bytes become inaccessible via lengths;
                 // the lease owner may release the corresponding blocks.
-                self.scope.synchronize()?;
-                if let (Some(saved), Some(state)) = (snapshot.as_ref(), self.recurrent.as_mut()) {
-                    saved.restore(&mut state.layers)?;
-                    infer_core::device::MemoryPort::synchronize(self.scope.device())?;
+                if let Some(state) = self.recurrent.as_mut() {
+                    state
+                        .verification_snapshot
+                        .as_ref()
+                        .unwrap()
+                        .restore_on(&mut state.layers, &self.scope)?;
                     // Logical lengths still refer to the pre-verification prefix.
                     self.prepare_recurrent(&retained, &retained_plan)?;
                 }
@@ -109,6 +124,7 @@ impl<T: Dtype, D: LlmBackend, M: DecoderModel<T, D>> Runtime<T, D, M> {
             self.scope.synchronize()?;
             Ok((output, retained_plan))
         })();
+        self.retained_request = Some(retained);
         self.finish_recurrent_step(result)
     }
 }
@@ -120,6 +136,35 @@ impl<T: Dtype, D: LlmBackend, M: DecoderReadout<T, D>> Runtime<T, D, M> {
     pub fn step_with_hidden(&mut self, req: &StepRequest) -> OpResult<TargetStep<T, D>> {
         let plan = self.build_plan(req)?;
         self.validate_eager_transaction(req)?;
+        let mut normalized_hidden =
+            Tensor::zeros([plan.num_tokens, self.dims.dim], self.scope.device())?;
+        let output = self.step_with_hidden_into(req, &mut normalized_hidden)?;
+        let n = output.materialized_tokens.iter().map(|&n| n as usize).sum();
+        Ok(TargetStep {
+            output,
+            normalized_hidden: normalized_hidden.narrow(0, 0, n)?,
+        })
+    }
+
+    /// Borrow caller-owned startup scratch; the caller consumes it before reuse.
+    pub fn step_with_hidden_into(
+        &mut self,
+        req: &StepRequest,
+        normalized_hidden: &mut Tensor<T, D>,
+    ) -> OpResult<StepOutput> {
+        let plan = self.build_plan(req)?;
+        self.validate_eager_transaction(req)?;
+        if normalized_hidden.shape().len() != 2
+            || normalized_hidden.shape()[0] < plan.num_tokens
+            || normalized_hidden.shape()[1] != self.dims.dim
+            || !normalized_hidden.is_contiguous()
+            || infer_core::device::Device::device_id(normalized_hidden.device())
+                != infer_core::device::Device::device_id(self.scope.device())
+        {
+            return Err(OpError::Shape(
+                "target hidden workspace capacity/layout/device mismatch".into(),
+            ));
+        }
         let (output, retained_plan) = if req.draft_tokens.is_empty() {
             self.prepare_recurrent(req, &plan)?;
             let result = (|| {
@@ -133,7 +178,7 @@ impl<T: Dtype, D: LlmBackend, M: DecoderReadout<T, D>> Runtime<T, D, M> {
         };
         let result = (|| {
             let n = retained_plan.num_tokens;
-            let mut normalized_hidden = Tensor::zeros([n, self.dims.dim], self.scope.device())?;
+            let mut normalized_hidden = normalized_hidden.narrow(0, 0, n)?;
             let hidden = Hidden {
                 stream: self.hidden.stream.narrow(0, 0, n)?,
                 pending: None,
@@ -142,10 +187,7 @@ impl<T: Dtype, D: LlmBackend, M: DecoderReadout<T, D>> Runtime<T, D, M> {
             self.model
                 .normalize_hidden_into(&hidden, &mut normalized_hidden, &ctx)?;
             self.scope.synchronize()?;
-            Ok(TargetStep {
-                output,
-                normalized_hidden,
-            })
+            Ok(output)
         })();
         if result.is_err() {
             for seq in &req.seqs {

--- a/crates/infer-worker/src/application/runtime/speculative.rs
+++ b/crates/infer-worker/src/application/runtime/speculative.rs
@@ -88,57 +88,76 @@ impl<T: Dtype, D: LlmBackend, M: DecoderModel<T, D>> Runtime<T, D, M> {
         let mut retained = self.retained_request.take().unwrap_or_else(|| {
             StepRequest::workspace(self.cap_batch, self.cap_num_tokens, self.max_blocks_per_seq)
         });
-        let result = (|| {
-            if let Some(state) = self.recurrent.as_mut() {
-                state.snapshot(req, &self.scope)?;
-            }
-            self.upload_index(plan, req)?;
-            self.prepare_multimodal(req)?;
-            let output = self.step_eager_with_input(plan, req, device_input)?;
-            if output.materialized_tokens.len() != req.seqs.len()
-                || req
-                    .seqs
-                    .iter()
-                    .zip(&output.materialized_tokens)
-                    .any(|(seq, &n)| n == 0 || n as usize > seq.input_ids.len())
-            {
-                return Err(OpError::Shape(
-                    "invalid speculative retention length".into(),
-                ));
-            }
-            retained.retain_from(req, &output.materialized_tokens);
-            let retained_plan = self.build_plan(&retained)?;
-            if retained_plan.num_tokens != plan.num_tokens {
-                // GDN has already consumed rejected inputs. Restore the entire
-                // participating batch, then replay just its retained prefixes.
-                // Full-attention KV suffix bytes become inaccessible via lengths;
-                // the lease owner may release the corresponding blocks.
-                if let Some(state) = self.recurrent.as_mut() {
-                    state
-                        .verification_snapshot
-                        .as_ref()
-                        .unwrap()
-                        .restore_on(&mut state.layers, &self.scope)?;
-                    // Logical lengths still refer to the pre-verification prefix.
-                    self.prepare_recurrent(&retained, &retained_plan)?;
-                }
-                self.upload_index(&retained_plan, &retained)?;
-                let input = match device_input {
-                    // The direct path is single-sequence, so its retained tape
-                    // is a contiguous prefix. Multi-sequence repacking stays on
-                    // the ordinary host-input path.
-                    Some(input) => input.narrow(0, 0, retained_plan.num_tokens)?,
-                    None => self.input_ids_tensor(&retained, &retained_plan)?,
+        let result =
+            (|| {
+                let metrics = self.execution_metrics.clone();
+                let operation = |phase, tokens, workspace| {
+                    ExecutionPlan::eager(phase, plan.batch, tokens, workspace)
                 };
-                self.run_layers(&retained_plan, &input)?;
-            }
-            if let Some(state) = &mut self.recurrent {
-                state.retain_step(&retained);
-            }
-            // No request may observe committed state until replay completes.
-            self.scope.synchronize()?;
-            Ok((output, retained_plan))
-        })();
+                if let Some(state) = self.recurrent.as_mut() {
+                    operation(Phase::Snapshot, plan.num_tokens, WorkspaceUse::Recurrent)
+                        .execute(&metrics, |_| state.snapshot(req, &self.scope))?;
+                }
+                self.upload_index(plan, req)?;
+                self.prepare_multimodal(req)?;
+                let workspace = if device_input.is_some() {
+                    WorkspaceUse::BorrowedTape
+                } else {
+                    WorkspaceUse::Runtime
+                };
+                let output = operation(Phase::Verify, plan.num_tokens, workspace)
+                    .execute(&metrics, |_| {
+                        self.step_eager_with_input(plan, req, device_input)
+                    })?;
+                if output.materialized_tokens.len() != req.seqs.len()
+                    || req
+                        .seqs
+                        .iter()
+                        .zip(&output.materialized_tokens)
+                        .any(|(seq, &n)| n == 0 || n as usize > seq.input_ids.len())
+                {
+                    return Err(OpError::Shape(
+                        "invalid speculative retention length".into(),
+                    ));
+                }
+                retained.retain_from(req, &output.materialized_tokens);
+                let retained_plan = self.build_plan(&retained)?;
+                if retained_plan.num_tokens != plan.num_tokens {
+                    // GDN has already consumed rejected inputs. Restore the entire
+                    // participating batch, then replay just its retained prefixes.
+                    // Full-attention KV suffix bytes become inaccessible via lengths;
+                    // the lease owner may release the corresponding blocks.
+                    if let Some(state) = self.recurrent.as_mut() {
+                        operation(Phase::Restore, plan.num_tokens, WorkspaceUse::Recurrent)
+                            .execute(&metrics, |_| {
+                                state
+                                    .verification_snapshot
+                                    .as_ref()
+                                    .unwrap()
+                                    .restore_on(&mut state.layers, &self.scope)
+                            })?;
+                        // Logical lengths still refer to the pre-verification prefix.
+                        self.prepare_recurrent(&retained, &retained_plan)?;
+                    }
+                    self.upload_index(&retained_plan, &retained)?;
+                    let input = match device_input {
+                        // The direct path is single-sequence, so its retained tape
+                        // is a contiguous prefix. Multi-sequence repacking stays on
+                        // the ordinary host-input path.
+                        Some(input) => input.narrow(0, 0, retained_plan.num_tokens)?,
+                        None => self.input_ids_tensor(&retained, &retained_plan)?,
+                    };
+                    operation(Phase::Replay, retained_plan.num_tokens, workspace)
+                        .execute(&metrics, |_| self.run_layers(&retained_plan, &input))?;
+                }
+                if let Some(state) = &mut self.recurrent {
+                    state.retain_step(&retained);
+                }
+                // No request may observe committed state until replay completes.
+                operation(Phase::Wait, retained_plan.num_tokens, workspace)
+                    .execute(&metrics, |_| self.scope.synchronize())?;
+                Ok((output, retained_plan))
+            })();
         self.retained_request = Some(retained);
         self.finish_recurrent_step(result)
     }
@@ -209,7 +228,15 @@ impl<T: Dtype, D: LlmBackend, M: DecoderReadout<T, D>> Runtime<T, D, M> {
             let result = (|| {
                 self.upload_index(&plan, req)?;
                 self.prepare_multimodal(req)?;
-                self.step_eager(&plan, req)
+                ExecutionPlan::eager(
+                    Phase::Prefill,
+                    plan.batch,
+                    plan.num_tokens,
+                    WorkspaceUse::Runtime,
+                )
+                .execute(&self.execution_metrics.clone(), |_| {
+                    self.step_eager(&plan, req)
+                })
             })();
             (self.finish_recurrent_step(result)?, plan)
         } else {
@@ -223,9 +250,18 @@ impl<T: Dtype, D: LlmBackend, M: DecoderReadout<T, D>> Runtime<T, D, M> {
                 pending: None,
             };
             let ctx = crate::domain::exec::StepCtx::new(&self.scope, &retained_plan);
-            self.model
-                .normalize_hidden_into(&hidden, &mut normalized_hidden, &ctx)?;
-            self.scope.synchronize()?;
+            ExecutionPlan::eager(
+                Phase::Readout,
+                retained_plan.batch,
+                n,
+                WorkspaceUse::Runtime,
+            )
+            .execute(&self.execution_metrics, |_| {
+                self.model
+                    .normalize_hidden_into(&hidden, &mut normalized_hidden, &ctx)
+            })?;
+            ExecutionPlan::eager(Phase::Wait, retained_plan.batch, n, WorkspaceUse::Runtime)
+                .execute(&self.execution_metrics, |_| self.scope.synchronize())?;
             Ok(output)
         })();
         if result.is_err() {

--- a/crates/infer-worker/src/application/sampler_stack.rs
+++ b/crates/infer-worker/src/application/sampler_stack.rs
@@ -1,7 +1,7 @@
 use crate::domain::dtype::Dtype;
 use crate::domain::exec::StepCtx;
 use crate::domain::ports::backend::LlmBackend;
-use crate::domain::ports::sampler::{AcceptReject, SampleBatch, Sampler, SamplingParams};
+use crate::domain::ports::sampler::{SampleBatch, Sampler, SamplingParams};
 use crate::domain::ports::{OpError, OpResult};
 use crate::domain::tensor::Tensor;
 use rand::rngs::StdRng;
@@ -98,112 +98,6 @@ impl<T: Dtype, D: LlmBackend> Sampler<T, D> for GreedySampler {
             tokens.push(sample_filtered_row(row_logits, *params, draw)?);
         }
         Ok(SampleBatch { tokens })
-    }
-
-    fn probs(
-        &self,
-        logits: &Tensor<T, D>,
-        _params: &[SamplingParams],
-        out: &mut Tensor<f32, D>,
-        _ctx: &StepCtx<'_, D>,
-    ) -> OpResult<()> {
-        let shape = logits.shape().as_slice();
-        if shape.len() != 2 {
-            return Err(OpError::Shape(format!(
-                "GreedySampler::probs: expected 2D logits, got {:?}",
-                shape
-            )));
-        }
-        if out.numel() != logits.numel() {
-            return Err(OpError::Shape(format!(
-                "GreedySampler::probs: out numel {} != logits {}",
-                out.numel(),
-                logits.numel()
-            )));
-        }
-        let vocab = shape[1];
-        let host = logits.to_host_vec()?;
-        let mut probs = vec![0.0f32; host.len()];
-        for (row_in, row_out) in host.chunks(vocab).zip(probs.chunks_mut(vocab)) {
-            let max = row_in
-                .iter()
-                .map(T::read_f64)
-                .fold(f64::NEG_INFINITY, f64::max);
-            let mut sum = 0.0f64;
-            for (src, dst) in row_in.iter().zip(row_out.iter_mut()) {
-                let p = (T::read_f64(src) - max).exp();
-                *dst = p as f32;
-                sum += p;
-            }
-            if sum > 0.0 {
-                for dst in row_out {
-                    *dst /= sum as f32;
-                }
-            }
-        }
-        out.upload_from_host(&probs)
-    }
-
-    fn verify(
-        &self,
-        target_logits: &Tensor<T, D>,
-        draft_tokens: &[i32],
-        _draft_probs: &Tensor<f32, D>,
-        _params: &[SamplingParams],
-        ctx: &StepCtx<'_, D>,
-    ) -> OpResult<AcceptReject> {
-        let shape = target_logits.shape().as_slice();
-        if shape.len() != 2 {
-            return Err(OpError::Shape(format!(
-                "GreedySampler::verify: expected 2D logits, got {:?}",
-                shape
-            )));
-        }
-        let vocab = shape[1];
-        let expected = ctx
-            .plan()
-            .q_lens
-            .iter()
-            .map(|&q| q.max(0) as usize)
-            .sum::<usize>();
-        if draft_tokens.len() != expected {
-            return Err(OpError::Shape(format!(
-                "GreedySampler::verify: draft_tokens {} != planned tokens {}",
-                draft_tokens.len(),
-                expected
-            )));
-        }
-        let host = target_logits.to_host_vec()?;
-        let mut accepted_count = Vec::with_capacity(ctx.plan().batch);
-        let mut bonus_token = Vec::with_capacity(ctx.plan().batch);
-        let mut offset = 0usize;
-        for &q_len in &ctx.plan().q_lens {
-            let q = q_len.max(0) as usize;
-            let mut accepted = 0usize;
-            for row_in_seq in 0..q {
-                let row = offset + row_in_seq;
-                let (token_id, _) = argmax_row(&host[row * vocab..(row + 1) * vocab])?;
-                if token_id == draft_tokens[row] {
-                    accepted += 1;
-                } else {
-                    break;
-                }
-            }
-            let bonus_row = offset + accepted.min(q.saturating_sub(1));
-            let row = &host[bonus_row * vocab..(bonus_row + 1) * vocab];
-            let (token_id, _) = argmax_row(row)?;
-            bonus_token.push(crate::domain::plan::SampledToken {
-                token_id,
-                logprob: log_softmax_at(row, token_id as usize) as f32,
-                top_logprobs: Vec::new(),
-            });
-            accepted_count.push(accepted as u32);
-            offset += q;
-        }
-        Ok(AcceptReject {
-            accepted_count,
-            bonus_token,
-        })
     }
 }
 
@@ -377,55 +271,11 @@ fn argmax_row<T: Dtype>(row: &[T]) -> OpResult<(i32, f64)> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::domain::exec::{HostScope, StepCtx};
-    use crate::domain::plan::{BatchKind, BatchPlan};
-    use crate::infrastructure::cpu::Cpu;
 
     #[test]
     fn greedy_ties_choose_the_lowest_token_id() {
         assert_eq!(argmax_row(&[23.625f32, 23.625, 0.0]).unwrap().0, 0);
         assert_eq!(argmax_row(&[0.0f32, 23.625, 23.625]).unwrap().0, 1);
-    }
-
-    #[test]
-    fn greedy_verify_returns_per_sequence_acceptance() {
-        let cpu = Cpu;
-        let scope = HostScope::new(cpu);
-        let plan = BatchPlan {
-            kind: BatchKind::Spec {
-                mask: crate::domain::plan::MaskMode::Causal,
-                mask_handle: None,
-            },
-            num_tokens: 3,
-            batch: 2,
-            q_lens: vec![2, 1],
-            kv_lens: vec![2, 1],
-            seq_positions: vec![0, 0],
-            rope_positions: vec![0, 1, 0],
-            max_blocks_per_seq: 2,
-            block_size: 16,
-            total_q_tiles: 1,
-        };
-        let ctx = StepCtx::new(&scope, &plan);
-        let logits = Tensor::from_host_slice(
-            &[
-                0.0f32, 3.0, 1.0, 0.0, // row 0 predicts token 1: accepted
-                0.0, 1.0, 4.0, 0.0, // row 1 predicts token 2: rejects draft token 3
-                5.0, 0.0, 1.0, 0.0, // row 2 predicts token 0: accepted
-            ],
-            [3, 4],
-            &cpu,
-        )
-        .unwrap();
-        let draft_probs = Tensor::from_host_slice(&[1.0f32], [1], &cpu).unwrap();
-
-        let verdict = GreedySampler
-            .verify(&logits, &[1, 3, 0], &draft_probs, &[], &ctx)
-            .unwrap();
-
-        assert_eq!(verdict.accepted_count, vec![1, 1]);
-        assert_eq!(verdict.bonus_token[0].token_id, 2);
-        assert_eq!(verdict.bonus_token[1].token_id, 0);
     }
 
     #[test]

--- a/crates/infer-worker/src/application/serve_execution.rs
+++ b/crates/infer-worker/src/application/serve_execution.rs
@@ -22,6 +22,9 @@ pub struct ServingStep<'a, M: DecoderModel<bf16, Cuda>> {
 
 pub trait ServingExecution<M: DecoderModel<bf16, Cuda>> {
     const SPECULATIVE: bool;
+    fn prepare(&mut self, _runner: &Runtime<bf16, Cuda, M>) -> OpResult<()> {
+        Ok(())
+    }
     fn step(&mut self, ctx: ServingStep<'_, M>) -> OpResult<()>;
 }
 

--- a/crates/infer-worker/src/application/serve_execution.rs
+++ b/crates/infer-worker/src/application/serve_execution.rs
@@ -1,0 +1,37 @@
+//! Compile-time serving extension. Ordinary serving has no draft state.
+use crate::application::runtime::Runtime;
+use crate::application::worker_state::{ActiveSeqMap, PrefillSeqMap};
+use crate::domain::global_kv_alloc::GlobalKvAllocator;
+use crate::domain::model::DecoderModel;
+use crate::domain::ports::{OpError, OpResult};
+use crate::infrastructure::cuda::Cuda;
+use crate::infrastructure::transport::{control_pump::ControlPump, data_pump::DataPump};
+use half::bf16;
+use infer_protocol::scheduler_to_worker_data::PrefillBatchCmd;
+
+pub struct ServingStep<'a, M: DecoderModel<bf16, Cuda>> {
+    pub runner: &'a mut Runtime<bf16, Cuda, M>,
+    pub active: &'a mut ActiveSeqMap,
+    pub prefilling: &'a mut PrefillSeqMap,
+    pub allocator: &'a mut GlobalKvAllocator,
+    pub control: &'a ControlPump,
+    pub data: &'a DataPump,
+    pub eos_ids: &'a [i32],
+    pub prefills: &'a mut Vec<PrefillBatchCmd>,
+}
+
+pub trait ServingExecution<M: DecoderModel<bf16, Cuda>> {
+    const SPECULATIVE: bool;
+    fn step(&mut self, ctx: ServingStep<'_, M>) -> OpResult<()>;
+}
+
+pub struct OrdinaryExecution;
+impl<M: DecoderModel<bf16, Cuda>> ServingExecution<M> for OrdinaryExecution {
+    const SPECULATIVE: bool = false;
+    fn step(&mut self, _ctx: ServingStep<'_, M>) -> OpResult<()> {
+        Err(OpError::unsupported(
+            "ordinary execution",
+            "speculative serving entrypoint",
+        ))
+    }
+}

--- a/crates/infer-worker/src/application/serve_loop.rs
+++ b/crates/infer-worker/src/application/serve_loop.rs
@@ -414,6 +414,11 @@ where
         bs.capture_sizes.clone(),
     )
     .map_err(|e| format!("Runtime::new: {:?}", e))?;
+    if E::SPECULATIVE {
+        runner
+            .prepare_speculative()
+            .map_err(|e| format!("MTP workspace: {e}"))?;
+    }
     if !peer_handles.is_empty() {
         let watchdog = peer_watchdog
             .take()

--- a/crates/infer-worker/src/application/serve_loop.rs
+++ b/crates/infer-worker/src/application/serve_loop.rs
@@ -419,6 +419,9 @@ where
             .prepare_speculative()
             .map_err(|e| format!("MTP workspace: {e}"))?;
     }
+    execution
+        .prepare(&runner)
+        .map_err(|e| format!("execution preparation: {e}"))?;
     if !peer_handles.is_empty() {
         let watchdog = peer_watchdog
             .take()

--- a/crates/infer-worker/src/application/serve_loop.rs
+++ b/crates/infer-worker/src/application/serve_loop.rs
@@ -193,7 +193,42 @@ pub fn run_with_model<M>(
 where
     M: DecoderModel<bf16, Cuda> + 'static,
 {
+    run_with_model_and_execution(
+        control,
+        data,
+        model,
+        bs,
+        follower_factories,
+        eos_ids,
+        profile_cuda_steps,
+        crate::application::serve_execution::OrdinaryExecution,
+    )
+}
+
+#[allow(clippy::too_many_arguments)]
+pub fn run_with_model_and_execution<M, E>(
+    control: &ControlPump,
+    data: &DataPump,
+    model: M,
+    bs: Bootstrap<'_>,
+    follower_factories: Vec<RuntimeFollowerFactory<M>>,
+    eos_ids: &[i32],
+    profile_cuda_steps: Option<u32>,
+    mut execution: E,
+) -> Result<(), String>
+where
+    M: DecoderModel<bf16, Cuda> + 'static,
+    E: crate::application::serve_execution::ServingExecution<M>,
+{
     let _ = bs.load_cfg;
+    if E::SPECULATIVE
+        && (bs.load.max_batch_seqs != 1
+            || bs.load.tp_size != 1
+            || bs.load.enable_prefix_caching
+            || profile_cuda_steps.is_some())
+    {
+        return Err("MTP serving requires one TP1 request, prefix caching disabled, and no ordinary decode profiler override".into());
+    }
     if bs.block_size != 1 {
         return Err(format!(
             "worker-owned KV allocator requires block_size=1, got {}",
@@ -818,7 +853,25 @@ where
         } else {
             1usize
         };
-        if !pending_prefills.is_empty() {
+        if E::SPECULATIVE {
+            let result = execution.step(crate::application::serve_execution::ServingStep {
+                runner: &mut runner,
+                active: &mut active,
+                prefilling: &mut prefilling,
+                allocator: &mut kv_allocator,
+                control,
+                data,
+                eos_ids,
+                prefills: &mut pending_prefills,
+            });
+            deferred_prefills.append(&mut pending_prefills);
+            if let Err(error) = result {
+                if error.is_fatal() {
+                    escalate_fatal_and_exit(control, &active, &prefilling, &error);
+                }
+                return Err(format!("speculative serving: {error}"));
+            }
+        } else if !pending_prefills.is_empty() {
             if trace_steps {
                 for cmd in &pending_prefills {
                     tr_pf_seqs += cmd.segments.len();

--- a/crates/infer-worker/src/application/speculative/commit.rs
+++ b/crates/infer-worker/src/application/speculative/commit.rs
@@ -1,0 +1,170 @@
+//! Commit exactly the retained target prefix to worker-owned KV leases.
+use crate::application::worker_state::ActiveSeqMap;
+use crate::domain::global_kv_alloc::{GlobalKvAllocator, KvLease};
+use crate::domain::plan::StepOutput;
+use crate::domain::ports::{OpError, OpResult};
+use infer_protocol::worker_to_scheduler_data::{
+    AssignedIndices, GeneratedToken, StepOutput as WireOutput,
+};
+
+pub(crate) fn commit_decode(
+    active: &mut ActiveSeqMap,
+    allocator: &mut GlobalKvAllocator,
+    id: u64,
+    mut lease: KvLease,
+    output: StepOutput,
+) -> OpResult<WireOutput> {
+    let checked = (|| {
+        let seq = active
+            .get(&id)
+            .ok_or_else(|| OpError::Shape("missing speculative sequence".into()))?;
+        if output.tokens.len() != 1
+            || output.materialized_tokens.len() != 1
+            || output.finished.len() != 1
+            || output.accepted_drafts.as_ref().is_none_or(|a| a.len() != 1)
+        {
+            return Err(OpError::Shape("invalid speculative commit rows".into()));
+        }
+        let kept = output.materialized_tokens[0] as usize;
+        if kept == 0
+            || kept != output.tokens[0].len()
+            || kept > lease.len()
+            || seq
+                .generated_count
+                .checked_add(kept)
+                .is_none_or(|g| g > seq.max_tokens)
+            || seq.kv_len.checked_add(kept).is_none()
+        {
+            return Err(OpError::Shape("invalid speculative commit length".into()));
+        }
+        Ok(kept)
+    })();
+    let kept = match checked {
+        Ok(n) => n,
+        Err(e) => {
+            lease.release(allocator);
+            return Err(e);
+        }
+    };
+    lease.shrink_to(kept, allocator);
+    let tokens = &output.tokens[0];
+    let last = tokens.last().unwrap().token_id;
+    if let Err(e) = active
+        .get_mut(&id)
+        .unwrap()
+        .commit_accepted(last, kept, lease.as_slice())
+    {
+        lease.release(allocator);
+        return Err(OpError::Shape(e.into()));
+    }
+    let indices = lease.commit();
+    let mut assigned = Vec::new();
+    let mut start = 0;
+    while start < indices.len() {
+        let mut end = start + 1;
+        while end < indices.len()
+            && end - start < u16::MAX as usize
+            && indices[end] == indices[end - 1] + 1
+        {
+            end += 1;
+        }
+        assigned.push(AssignedIndices {
+            sequence_id: id,
+            base: indices[start],
+            len: (end - start) as u16,
+            token_ids: vec![],
+        });
+        start = end;
+    }
+    if output.finished[0] {
+        allocator.release_owned(&active.remove(&id).unwrap().block_table, false);
+    }
+    Ok(WireOutput {
+        prefill_done: vec![],
+        assigned_indices: assigned,
+        tokens: tokens
+            .iter()
+            .enumerate()
+            .map(|(i, t)| GeneratedToken {
+                sequence_id: id,
+                token_id: t.token_id,
+                finished: output.finished[0] && i + 1 == tokens.len(),
+            })
+            .collect(),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::application::worker_state::ActiveSeq;
+    use crate::domain::plan::SampledToken;
+    #[test]
+    fn malformed_commit_returns_all_provisional_slots_without_changing_the_sequence() {
+        let mut allocator = GlobalKvAllocator::new(16);
+        let prefix = allocator.lease(3).unwrap().commit();
+        let mut active = ActiveSeqMap::new();
+        active.insert(
+            7,
+            ActiveSeq::new(4, prefix.clone(), 10, false, Default::default()),
+        );
+        let lease = allocator.lease(4).unwrap();
+        let result = StepOutput {
+            tokens: vec![vec![]],
+            materialized_tokens: vec![2],
+            accepted_drafts: Some(vec![1]),
+            finished: vec![false],
+            hidden_tap: None,
+        };
+        assert!(commit_decode(&mut active, &mut allocator, 7, lease, result).is_err());
+        assert_eq!(allocator.outstanding(), 3);
+        assert_eq!(active[&7].block_table, prefix);
+        assert_eq!(active[&7].generated_count, 1);
+        assert_eq!(active[&7].last_token, 4);
+    }
+
+    #[test]
+    fn rejection_releases_suffix_and_finishing_releases_retained_history_once() {
+        for finished in [false, true] {
+            let mut allocator = GlobalKvAllocator::new(16);
+            let prefix = allocator.lease(3).unwrap().commit();
+            let mut active = ActiveSeqMap::new();
+            active.insert(7, ActiveSeq::new(4, prefix, 10, false, Default::default()));
+            let lease = allocator.lease(4).unwrap();
+            let result = StepOutput {
+                tokens: vec![
+                    vec![5, 6]
+                        .into_iter()
+                        .map(|token_id| SampledToken {
+                            token_id,
+                            logprob: 0.0,
+                            top_logprobs: vec![],
+                        })
+                        .collect(),
+                ],
+                materialized_tokens: vec![2],
+                accepted_drafts: Some(vec![1]),
+                finished: vec![finished],
+                hidden_tap: None,
+            };
+            let wire = commit_decode(&mut active, &mut allocator, 7, lease, result).unwrap();
+            assert_eq!(
+                wire.assigned_indices
+                    .iter()
+                    .map(|a| a.len as usize)
+                    .sum::<usize>(),
+                2
+            );
+            assert_eq!(
+                wire.tokens.iter().map(|t| t.finished).collect::<Vec<_>>(),
+                [false, finished]
+            );
+            assert_eq!(allocator.outstanding(), if finished { 0 } else { 5 });
+            if !finished {
+                assert_eq!(active[&7].generated_count, 3);
+                assert_eq!(active[&7].kv_len, 5);
+                assert_eq!(active[&7].last_token, 6);
+            }
+        }
+    }
+}

--- a/crates/infer-worker/src/application/speculative/mod.rs
+++ b/crates/infer-worker/src/application/speculative/mod.rs
@@ -1,0 +1,15 @@
+//! Speculative decoding components, independent of ordinary token sampling.
+
+mod verifier;
+
+pub use verifier::{GreedyVerifier, validate_sampling};
+
+mod mtp;
+pub mod prefill;
+mod session;
+pub use mtp::MtpProposer;
+pub use session::{MtpLimits, MtpSession, MtpStep};
+#[cfg(any(feature = "cuda", test))]
+mod commit;
+#[cfg(feature = "cuda")]
+pub mod serving;

--- a/crates/infer-worker/src/application/speculative/mtp.rs
+++ b/crates/infer-worker/src/application/speculative/mtp.rs
@@ -1,5 +1,6 @@
 //! MTP cache ownership, autoregressive drafting, and target-feature catch-up.
 use super::prefill::MtpPrefill;
+use crate::application::execution::{ExecutionMetrics, ExecutionPlan, Phase, WorkspaceUse};
 use crate::components::mtp::{MtpHead, MtpInput};
 use crate::domain::cache::ModelCacheView;
 use crate::domain::dtype::Dtype;
@@ -16,6 +17,7 @@ use crate::domain::tensor::Tensor;
 /// Catch-up overwrites them using actual target hidden states after verification,
 /// even when every draft was accepted. No target cache or sampling policy here.
 pub struct MtpProposer<T: Dtype, D: LlmBackend, H: DecoderReadout<T, D>> {
+    metrics: ExecutionMetrics,
     head: MtpHead<T, D, H>,
     kv: PagedKvPool<T, D>,
     alignment: MtpPrefill<T, D>,
@@ -65,6 +67,7 @@ impl<T: Dtype, D: LlmBackend, H: DecoderReadout<T, D>> MtpProposer<T, D, H> {
         let alignment = MtpPrefill::with_capacity(max_tokens, head.dims().dim, device)?;
         let workspace = MtpWorkspace::new(head.dims(), max_context, max_tokens, device)?;
         Ok(Self {
+            metrics: ExecutionMetrics::from_env("proposer"),
             head,
             kv,
             alignment,
@@ -72,6 +75,10 @@ impl<T: Dtype, D: LlmBackend, H: DecoderReadout<T, D>> MtpProposer<T, D, H> {
             max_context,
             max_tokens,
         })
+    }
+
+    pub(crate) fn prepare_metrics(&self, scope: &D::Scope) -> OpResult<()> {
+        self.metrics.prepare_gpu(scope)
     }
 
     pub fn reset(&mut self) {
@@ -97,6 +104,20 @@ impl<T: Dtype, D: LlmBackend, H: DecoderReadout<T, D>> MtpProposer<T, D, H> {
 
     /// Continuation catch-up can consume the same tape as target verification.
     pub(crate) fn observe_with_input(
+        &mut self,
+        ids: &[i32],
+        start: usize,
+        hidden: &Tensor<T, D>,
+        scope: &D::Scope,
+        device_input: Option<&Tensor<i32, D>>,
+    ) -> OpResult<()> {
+        ExecutionPlan::eager(Phase::CatchUp, 1, ids.len(), WorkspaceUse::Proposer)
+            .execute(&self.metrics.clone(), |_| {
+                self.observe_with_input_local(ids, start, hidden, scope, device_input)
+            })
+    }
+
+    fn observe_with_input_local(
         &mut self,
         ids: &[i32],
         start: usize,
@@ -154,7 +175,8 @@ impl<T: Dtype, D: LlmBackend, H: DecoderReadout<T, D>> MtpProposer<T, D, H> {
             Ok(())
         })();
         // Includes alignment copies and the catch-up forward, even on errors.
-        let completed = scope.synchronize();
+        let completed = ExecutionPlan::eager(Phase::Wait, 1, ids.len(), WorkspaceUse::Proposer)
+            .execute(&self.metrics, |_| scope.synchronize());
         result?;
         completed?;
         chunk.commit();
@@ -169,6 +191,18 @@ impl<T: Dtype, D: LlmBackend, H: DecoderReadout<T, D>> MtpProposer<T, D, H> {
     /// Host verification metadata and its matching device input tape. The tape
     /// remains valid until the next proposer operation; callers consume it now.
     pub(crate) fn draft_with_device(
+        &mut self,
+        pending: i32,
+        count: usize,
+        scope: &D::Scope,
+    ) -> OpResult<(Vec<i32>, Tensor<i32, D>)> {
+        ExecutionPlan::eager(Phase::Draft, 1, count, WorkspaceUse::Proposer)
+            .execute(&self.metrics.clone(), |_| {
+                self.draft_with_device_local(pending, count, scope)
+            })
+    }
+
+    fn draft_with_device_local(
         &mut self,
         pending: i32,
         count: usize,
@@ -226,7 +260,8 @@ impl<T: Dtype, D: LlmBackend, H: DecoderReadout<T, D>> MtpProposer<T, D, H> {
             }
             // Downloads use the device's default stream, which need not be the
             // caller's execution stream. Fence once after the complete chain.
-            scope.synchronize()?;
+            ExecutionPlan::eager(Phase::Wait, 1, count, WorkspaceUse::Proposer)
+                .execute(&self.metrics, |_| scope.synchronize())?;
             self.workspace.drafts(count)?.to_host_vec()
         })();
         // Workspace owns all intermediates; drain before reuse, including errors.

--- a/crates/infer-worker/src/application/speculative/mtp.rs
+++ b/crates/infer-worker/src/application/speculative/mtp.rs
@@ -1,0 +1,243 @@
+//! MTP cache ownership, autoregressive drafting, and target-feature catch-up.
+use super::prefill::MtpPrefill;
+use crate::components::mtp::{MtpHead, MtpInput};
+use crate::domain::cache::ModelCacheView;
+use crate::domain::dtype::Dtype;
+use crate::domain::exec::{ExecScope, StepCtx};
+use crate::domain::kv::{KvIndexTensors, KvQuantTier, PagedKvLayer, PagedKvPool};
+use crate::domain::model::DecoderReadout;
+use crate::domain::plan::{BatchKind, BatchPlan};
+use crate::domain::ports::backend::LlmBackend;
+use crate::domain::ports::{OpError, OpResult};
+use crate::domain::tensor::Tensor;
+
+/// One sequence's draft state. Speculative writes never advance `alignment`.
+/// Catch-up overwrites them using actual target hidden states after verification,
+/// even when every draft was accepted. No target cache or sampling policy here.
+pub struct MtpProposer<T: Dtype, D: LlmBackend, H: DecoderReadout<T, D>> {
+    head: MtpHead<T, D, H>,
+    kv: PagedKvPool<T, D>,
+    alignment: MtpPrefill<T, D>,
+    max_context: usize,
+    max_tokens: usize,
+}
+
+impl<T: Dtype, D: LlmBackend, H: DecoderReadout<T, D>> MtpProposer<T, D, H> {
+    pub fn new(
+        mut head: MtpHead<T, D, H>,
+        max_context: usize,
+        max_tokens: usize,
+        device: &D,
+    ) -> OpResult<Self> {
+        if max_context == 0
+            || max_context > i32::MAX as usize
+            || max_tokens == 0
+            || max_tokens > max_context
+            || head.cache_layout().has_linear()
+            || infer_core::device::Device::device_id(head.device())
+                != infer_core::device::Device::device_id(device)
+        {
+            return Err(OpError::Shape(
+                "invalid MTP proposer capacity or cache layout".into(),
+            ));
+        }
+        head.prepare(max_tokens, 1)?;
+        let kv_dim = head.dims().kv_dim;
+        let block_size = 16;
+        let num_blocks = max_context.div_ceil(block_size);
+        let kv = PagedKvPool {
+            layers: (0..head.cache_layout().num_full_layers())
+                .map(|_| {
+                    Ok(PagedKvLayer {
+                        k: Tensor::zeros([num_blocks, block_size, kv_dim], device)?,
+                        v: Tensor::zeros([num_blocks, block_size, kv_dim], device)?,
+                    })
+                })
+                .collect::<OpResult<_>>()?,
+            num_blocks,
+            block_size,
+            kv_dim,
+            quant: KvQuantTier::None,
+            seq_kv_len: Default::default(),
+        };
+        Ok(Self {
+            head,
+            kv,
+            alignment: MtpPrefill::default(),
+            max_context,
+            max_tokens,
+        })
+    }
+
+    pub fn reset(&mut self) {
+        self.alignment.reset();
+    }
+
+    /// The target has L cached tokens; this head has L-1 committed pairs.
+    pub fn committed_len(&self) -> usize {
+        self.alignment.pending().map_or(0, |(p, _)| p as usize)
+    }
+
+    /// Synchronize target outputs before calling. Default-stream alignment
+    /// copies are drained before launching on the supplied execution scope.
+    pub fn observe(
+        &mut self,
+        ids: &[i32],
+        start: usize,
+        hidden: &Tensor<T, D>,
+        scope: &D::Scope,
+    ) -> OpResult<()> {
+        self.validate(ids, start, scope)?;
+        if hidden.shape().as_slice() != [ids.len(), self.head.dims().dim]
+            || infer_core::device::Device::device_id(hidden.device())
+                != infer_core::device::Device::device_id(scope.device())
+        {
+            return Err(OpError::Shape(
+                "MTP target hidden shape/device mismatch".into(),
+            ));
+        }
+        scope.synchronize()?;
+        let positions = (start as i32..(start + ids.len()) as i32).collect::<Vec<_>>();
+        let chunk = self.alignment.prepare(ids, &positions, hidden)?;
+        infer_core::device::MemoryPort::synchronize(scope.device())?;
+        if !chunk.next_token_ids.is_empty() {
+            run_head(
+                &self.head,
+                &mut self.kv,
+                &chunk.next_token_ids,
+                chunk.positions[0] as usize,
+                &chunk.target_hidden,
+                scope,
+            )?;
+        }
+        scope.synchronize()?;
+        chunk.commit();
+        Ok(())
+    }
+
+    pub fn draft(&mut self, pending: i32, count: usize, scope: &D::Scope) -> OpResult<Vec<i32>> {
+        let (position, hidden) = self
+            .alignment
+            .pending()
+            .ok_or_else(|| OpError::Shape("MTP requires target prefill".into()))?;
+        self.validate(&[pending], position as usize, scope)?;
+        if count > self.max_tokens
+            || (position as usize)
+                .checked_add(count)
+                .is_none_or(|end| end > self.max_context)
+        {
+            return Err(OpError::Shape("MTP draft exceeds capacity".into()));
+        }
+        let mut conditioning = hidden.clone();
+        let mut token = pending;
+        let mut draft = Vec::with_capacity(count);
+        for i in 0..count {
+            let (next_hidden, plan) = run_head(
+                &self.head,
+                &mut self.kv,
+                &[token],
+                position as usize + i,
+                &conditioning,
+                scope,
+            )?;
+            let ctx = StepCtx::new(scope, &plan);
+            let mut logits = Tensor::zeros([1, self.head.dims().vocab_size], scope.device())?;
+            self.head
+                .project_logits_into(&next_hidden, &mut logits, &ctx)?;
+            let predicted = D::argmax(&ctx, &logits)?;
+            if predicted.len() != 1
+                || predicted[0] < 0
+                || predicted[0] as usize >= self.head.dims().vocab_size
+            {
+                return Err(OpError::Shape("invalid MTP argmax output".into()));
+            }
+            token = predicted[0];
+            draft.push(token);
+            conditioning = next_hidden;
+        }
+        Ok(draft)
+    }
+
+    fn validate(&self, ids: &[i32], start: usize, scope: &D::Scope) -> OpResult<()> {
+        if scope.topology().tp.size != 1
+            || ids.is_empty()
+            || ids.len() > self.max_tokens
+            || infer_core::device::Device::device_id(self.head.device())
+                != infer_core::device::Device::device_id(scope.device())
+            || start
+                .checked_add(ids.len())
+                .is_none_or(|end| end > self.max_context)
+            || ids
+                .iter()
+                .any(|&id| id < 0 || id as usize >= self.head.dims().vocab_size)
+        {
+            return Err(OpError::Shape(
+                "MTP requires valid text tokens, capacity, and TP1".into(),
+            ));
+        }
+        Ok(())
+    }
+}
+
+fn run_head<T: Dtype, D: LlmBackend, H: DecoderReadout<T, D>>(
+    head: &MtpHead<T, D, H>,
+    kv: &mut PagedKvPool<T, D>,
+    ids: &[i32],
+    start: usize,
+    hidden: &Tensor<T, D>,
+    scope: &D::Scope,
+) -> OpResult<(Tensor<T, D>, BatchPlan)> {
+    let n = ids.len();
+    let device = scope.device();
+    let ints = |v: &[i32]| Tensor::from_host_slice(v, [v.len()], device);
+    let (cu, req, tile) = BatchPlan::plan_ragged_tiles(&[n as i32]);
+    let positions = (start as i32..(start + n) as i32).collect::<Vec<_>>();
+    let plan = BatchPlan {
+        kind: if n == 1 {
+            BatchKind::DecodeOnly
+        } else {
+            BatchKind::Ragged
+        },
+        num_tokens: n,
+        batch: 1,
+        q_lens: vec![n as i32],
+        kv_lens: vec![(start + n) as i32],
+        seq_positions: vec![start as i32],
+        rope_positions: positions.clone(),
+        max_blocks_per_seq: kv.num_blocks,
+        block_size: kv.block_size,
+        total_q_tiles: req.len() as i32,
+    };
+    let index = KvIndexTensors {
+        block_tables: Tensor::from_host_slice(
+            &(0..kv.num_blocks as i32).collect::<Vec<_>>(),
+            [1, kv.num_blocks],
+            device,
+        )?,
+        cu_q_lens: ints(&cu)?,
+        kv_lens: ints(&plan.kv_lens)?,
+        seq_positions: ints(&plan.seq_positions)?,
+        seq_lens_step: ints(&plan.q_lens)?,
+        rope_positions: ints(&positions)?,
+        block2req: ints(&req)?,
+        block2tile: ints(&tile)?,
+        valid_q_tiles: ints(&[req.len() as i32])?,
+        valid_suffix_q_tiles: ints(&[req.len() as i32])?,
+    };
+    let input = ints(ids)?;
+    let mut output = Tensor::zeros([n, head.dims().dim], device)?;
+    let result = head.forward_hidden_into(
+        MtpInput {
+            next_token_ids: &input,
+            target_hidden: hidden,
+        },
+        &mut ModelCacheView::full(kv, &index),
+        &mut output,
+        &StepCtx::new(scope, &plan),
+    );
+    // These local control tensors must outlive all GPU readers, including errors.
+    let completed = scope.synchronize();
+    result?;
+    completed?;
+    Ok((output, plan))
+}

--- a/crates/infer-worker/src/application/speculative/mtp.rs
+++ b/crates/infer-worker/src/application/speculative/mtp.rs
@@ -92,7 +92,28 @@ impl<T: Dtype, D: LlmBackend, H: DecoderReadout<T, D>> MtpProposer<T, D, H> {
         hidden: &Tensor<T, D>,
         scope: &D::Scope,
     ) -> OpResult<()> {
+        self.observe_with_input(ids, start, hidden, scope, None)
+    }
+
+    /// Continuation catch-up can consume the same tape as target verification.
+    pub(crate) fn observe_with_input(
+        &mut self,
+        ids: &[i32],
+        start: usize,
+        hidden: &Tensor<T, D>,
+        scope: &D::Scope,
+        device_input: Option<&Tensor<i32, D>>,
+    ) -> OpResult<()> {
         self.validate(ids, start, scope)?;
+        if let Some(input) = device_input
+            && (self.alignment.pending().is_none()
+                || input.shape().as_slice() != [ids.len()]
+                || !input.is_contiguous()
+                || infer_core::device::Device::device_id(input.device())
+                    != infer_core::device::Device::device_id(scope.device()))
+        {
+            return Err(OpError::Shape("invalid MTP catch-up device tape".into()));
+        }
         if hidden.shape().as_slice() != [ids.len(), self.head.dims().dim]
             || infer_core::device::Device::device_id(hidden.device())
                 != infer_core::device::Device::device_id(scope.device())
@@ -105,12 +126,24 @@ impl<T: Dtype, D: LlmBackend, H: DecoderReadout<T, D>> MtpProposer<T, D, H> {
         let chunk = self.alignment.prepare_on(ids, positions, hidden, scope)?;
         let result = (|| {
             if !chunk.next_token_ids.is_empty() {
-                self.workspace
-                    .prepare_observe(&chunk.next_token_ids, chunk.positions[0] as usize)?;
+                let input = match device_input {
+                    Some(input) => {
+                        self.workspace.prepare_observe_index(
+                            chunk.next_token_ids.len(),
+                            chunk.positions[0] as usize,
+                        )?;
+                        input.clone()
+                    }
+                    None => {
+                        self.workspace
+                            .prepare_observe(&chunk.next_token_ids, chunk.positions[0] as usize)?;
+                        self.workspace.input(chunk.next_token_ids.len())?
+                    }
+                };
                 run_head(
                     &self.head,
                     &mut self.kv,
-                    &self.workspace.input(chunk.next_token_ids.len())?,
+                    &input,
                     &chunk.target_hidden,
                     &mut self.workspace.hidden(0, chunk.next_token_ids.len())?,
                     &self.workspace.index(0, chunk.next_token_ids.len())?,
@@ -129,6 +162,18 @@ impl<T: Dtype, D: LlmBackend, H: DecoderReadout<T, D>> MtpProposer<T, D, H> {
     }
 
     pub fn draft(&mut self, pending: i32, count: usize, scope: &D::Scope) -> OpResult<Vec<i32>> {
+        self.draft_with_device(pending, count, scope)
+            .map(|(ids, _)| ids)
+    }
+
+    /// Host verification metadata and its matching device input tape. The tape
+    /// remains valid until the next proposer operation; callers consume it now.
+    pub(crate) fn draft_with_device(
+        &mut self,
+        pending: i32,
+        count: usize,
+        scope: &D::Scope,
+    ) -> OpResult<(Vec<i32>, Tensor<i32, D>)> {
         let (position, hidden) = self
             .alignment
             .pending()
@@ -141,13 +186,17 @@ impl<T: Dtype, D: LlmBackend, H: DecoderReadout<T, D>> MtpProposer<T, D, H> {
         {
             return Err(OpError::Shape("MTP draft exceeds capacity".into()));
         }
-        if count == 0 {
-            return Ok(Vec::new());
-        }
         let mut conditioning = hidden.clone();
         self.workspace
             .prepare_draft(pending, position as usize, count)?;
         let result = (|| {
+            // The head reads pending from the packed control upload. Preserve
+            // it beside the draft outputs for target's contiguous input tape.
+            D::copy_tensor(
+                scope,
+                &self.workspace.token(0)?,
+                &mut self.workspace.input(1)?,
+            )?;
             for i in 0..count {
                 self.workspace.set_decode_position(position as usize + i);
                 let mut next_hidden = self.workspace.hidden(i % 2, 1)?;
@@ -191,7 +240,7 @@ impl<T: Dtype, D: LlmBackend, H: DecoderReadout<T, D>> MtpProposer<T, D, H> {
         {
             return Err(OpError::Shape("invalid MTP argmax output".into()));
         }
-        Ok(draft)
+        Ok((draft, self.workspace.input(count + 1)?))
     }
 
     fn validate(&self, ids: &[i32], start: usize, scope: &D::Scope) -> OpResult<()> {

--- a/crates/infer-worker/src/application/speculative/mtp.rs
+++ b/crates/infer-worker/src/application/speculative/mtp.rs
@@ -6,7 +6,8 @@ use crate::domain::dtype::Dtype;
 use crate::domain::exec::{ExecScope, StepCtx};
 use crate::domain::kv::{KvIndexTensors, KvQuantTier, PagedKvLayer, PagedKvPool};
 use crate::domain::model::DecoderReadout;
-use crate::domain::plan::{BatchKind, BatchPlan};
+use crate::domain::mtp_scratch::MtpWorkspace;
+use crate::domain::plan::BatchPlan;
 use crate::domain::ports::backend::LlmBackend;
 use crate::domain::ports::{OpError, OpResult};
 use crate::domain::tensor::Tensor;
@@ -20,6 +21,7 @@ pub struct MtpProposer<T: Dtype, D: LlmBackend, H: DecoderReadout<T, D>> {
     alignment: MtpPrefill<T, D>,
     max_context: usize,
     max_tokens: usize,
+    workspace: MtpWorkspace<T, D>,
 }
 
 impl<T: Dtype, D: LlmBackend, H: DecoderReadout<T, D>> MtpProposer<T, D, H> {
@@ -60,10 +62,13 @@ impl<T: Dtype, D: LlmBackend, H: DecoderReadout<T, D>> MtpProposer<T, D, H> {
             quant: KvQuantTier::None,
             seq_kv_len: Default::default(),
         };
+        let alignment = MtpPrefill::with_capacity(max_tokens, head.dims().dim, device)?;
+        let workspace = MtpWorkspace::new(head.dims(), max_context, max_tokens, device)?;
         Ok(Self {
             head,
             kv,
-            alignment: MtpPrefill::default(),
+            alignment,
+            workspace,
             max_context,
             max_tokens,
         })
@@ -78,8 +83,8 @@ impl<T: Dtype, D: LlmBackend, H: DecoderReadout<T, D>> MtpProposer<T, D, H> {
         self.alignment.pending().map_or(0, |(p, _)| p as usize)
     }
 
-    /// Synchronize target outputs before calling. Default-stream alignment
-    /// copies are drained before launching on the supplied execution scope.
+    /// Synchronize target outputs before calling. Alignment copies and catch-up
+    /// execute in order on the supplied scope and complete before commit.
     pub fn observe(
         &mut self,
         ids: &[i32],
@@ -96,21 +101,29 @@ impl<T: Dtype, D: LlmBackend, H: DecoderReadout<T, D>> MtpProposer<T, D, H> {
                 "MTP target hidden shape/device mismatch".into(),
             ));
         }
-        scope.synchronize()?;
-        let positions = (start as i32..(start + ids.len()) as i32).collect::<Vec<_>>();
-        let chunk = self.alignment.prepare(ids, &positions, hidden)?;
-        infer_core::device::MemoryPort::synchronize(scope.device())?;
-        if !chunk.next_token_ids.is_empty() {
-            run_head(
-                &self.head,
-                &mut self.kv,
-                &chunk.next_token_ids,
-                chunk.positions[0] as usize,
-                &chunk.target_hidden,
-                scope,
-            )?;
-        }
-        scope.synchronize()?;
+        let positions = self.workspace.positions(start, ids.len());
+        let chunk = self.alignment.prepare_on(ids, positions, hidden, scope)?;
+        let result = (|| {
+            if !chunk.next_token_ids.is_empty() {
+                self.workspace
+                    .prepare_observe(&chunk.next_token_ids, chunk.positions[0] as usize)?;
+                run_head(
+                    &self.head,
+                    &mut self.kv,
+                    &self.workspace.input(chunk.next_token_ids.len())?,
+                    &chunk.target_hidden,
+                    &mut self.workspace.hidden(0, chunk.next_token_ids.len())?,
+                    &self.workspace.index(0, chunk.next_token_ids.len())?,
+                    &self.workspace.plan,
+                    scope,
+                )?;
+            }
+            Ok(())
+        })();
+        // Includes alignment copies and the catch-up forward, even on errors.
+        let completed = scope.synchronize();
+        result?;
+        completed?;
         chunk.commit();
         Ok(())
     }
@@ -128,32 +141,55 @@ impl<T: Dtype, D: LlmBackend, H: DecoderReadout<T, D>> MtpProposer<T, D, H> {
         {
             return Err(OpError::Shape("MTP draft exceeds capacity".into()));
         }
+        if count == 0 {
+            return Ok(Vec::new());
+        }
         let mut conditioning = hidden.clone();
-        let mut token = pending;
-        let mut draft = Vec::with_capacity(count);
-        for i in 0..count {
-            let (next_hidden, plan) = run_head(
-                &self.head,
-                &mut self.kv,
-                &[token],
-                position as usize + i,
-                &conditioning,
-                scope,
-            )?;
-            let ctx = StepCtx::new(scope, &plan);
-            let mut logits = Tensor::zeros([1, self.head.dims().vocab_size], scope.device())?;
-            self.head
-                .project_logits_into(&next_hidden, &mut logits, &ctx)?;
-            let predicted = D::argmax(&ctx, &logits)?;
-            if predicted.len() != 1
-                || predicted[0] < 0
-                || predicted[0] as usize >= self.head.dims().vocab_size
-            {
-                return Err(OpError::Shape("invalid MTP argmax output".into()));
+        self.workspace
+            .prepare_draft(pending, position as usize, count)?;
+        let result = (|| {
+            for i in 0..count {
+                self.workspace.set_decode_position(position as usize + i);
+                let mut next_hidden = self.workspace.hidden(i % 2, 1)?;
+                run_head(
+                    &self.head,
+                    &mut self.kv,
+                    &self.workspace.token(i)?,
+                    &conditioning,
+                    &mut next_hidden,
+                    &self.workspace.index(i, 1)?,
+                    &self.workspace.plan,
+                    scope,
+                )?;
+                let ctx = StepCtx::new(scope, &self.workspace.plan);
+                self.head
+                    .project_logits_into(&next_hidden, &mut self.workspace.logits, &ctx)?;
+                // The next embedding reads this device token directly. Only the
+                // completed draft vector crosses to the CPU, once per round.
+                D::argmax_into(
+                    &ctx,
+                    &self.workspace.logits,
+                    &mut self.workspace.token(i + 1)?,
+                    &self.workspace.argmax_ws,
+                    None,
+                )?;
+                conditioning = next_hidden;
             }
-            token = predicted[0];
-            draft.push(token);
-            conditioning = next_hidden;
+            // Downloads use the device's default stream, which need not be the
+            // caller's execution stream. Fence once after the complete chain.
+            scope.synchronize()?;
+            self.workspace.drafts(count)?.to_host_vec()
+        })();
+        // Workspace owns all intermediates; drain before reuse, including errors.
+        if result.is_err() {
+            let _ = scope.synchronize();
+        }
+        let draft = result?;
+        if draft
+            .iter()
+            .any(|&id| id < 0 || id as usize >= self.head.dims().vocab_size)
+        {
+            return Err(OpError::Shape("invalid MTP argmax output".into()));
         }
         Ok(draft)
     }
@@ -179,65 +215,24 @@ impl<T: Dtype, D: LlmBackend, H: DecoderReadout<T, D>> MtpProposer<T, D, H> {
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 fn run_head<T: Dtype, D: LlmBackend, H: DecoderReadout<T, D>>(
     head: &MtpHead<T, D, H>,
     kv: &mut PagedKvPool<T, D>,
-    ids: &[i32],
-    start: usize,
+    ids: &Tensor<i32, D>,
     hidden: &Tensor<T, D>,
+    output: &mut Tensor<T, D>,
+    index: &KvIndexTensors<D>,
+    plan: &BatchPlan,
     scope: &D::Scope,
-) -> OpResult<(Tensor<T, D>, BatchPlan)> {
-    let n = ids.len();
-    let device = scope.device();
-    let ints = |v: &[i32]| Tensor::from_host_slice(v, [v.len()], device);
-    let (cu, req, tile) = BatchPlan::plan_ragged_tiles(&[n as i32]);
-    let positions = (start as i32..(start + n) as i32).collect::<Vec<_>>();
-    let plan = BatchPlan {
-        kind: if n == 1 {
-            BatchKind::DecodeOnly
-        } else {
-            BatchKind::Ragged
-        },
-        num_tokens: n,
-        batch: 1,
-        q_lens: vec![n as i32],
-        kv_lens: vec![(start + n) as i32],
-        seq_positions: vec![start as i32],
-        rope_positions: positions.clone(),
-        max_blocks_per_seq: kv.num_blocks,
-        block_size: kv.block_size,
-        total_q_tiles: req.len() as i32,
-    };
-    let index = KvIndexTensors {
-        block_tables: Tensor::from_host_slice(
-            &(0..kv.num_blocks as i32).collect::<Vec<_>>(),
-            [1, kv.num_blocks],
-            device,
-        )?,
-        cu_q_lens: ints(&cu)?,
-        kv_lens: ints(&plan.kv_lens)?,
-        seq_positions: ints(&plan.seq_positions)?,
-        seq_lens_step: ints(&plan.q_lens)?,
-        rope_positions: ints(&positions)?,
-        block2req: ints(&req)?,
-        block2tile: ints(&tile)?,
-        valid_q_tiles: ints(&[req.len() as i32])?,
-        valid_suffix_q_tiles: ints(&[req.len() as i32])?,
-    };
-    let input = ints(ids)?;
-    let mut output = Tensor::zeros([n, head.dims().dim], device)?;
-    let result = head.forward_hidden_into(
+) -> OpResult<()> {
+    head.forward_hidden_into(
         MtpInput {
-            next_token_ids: &input,
+            next_token_ids: ids,
             target_hidden: hidden,
         },
-        &mut ModelCacheView::full(kv, &index),
-        &mut output,
-        &StepCtx::new(scope, &plan),
-    );
-    // These local control tensors must outlive all GPU readers, including errors.
-    let completed = scope.synchronize();
-    result?;
-    completed?;
-    Ok((output, plan))
+        &mut ModelCacheView::full(kv, index),
+        output,
+        &StepCtx::new(scope, plan),
+    )
 }

--- a/crates/infer-worker/src/application/speculative/prefill.rs
+++ b/crates/infer-worker/src/application/speculative/prefill.rs
@@ -5,12 +5,22 @@ use crate::domain::ports::backend::LlmBackend;
 use crate::domain::ports::{OpError, OpResult};
 use crate::domain::tensor::Tensor;
 
+type AlignmentScratch<T, D> = (Tensor<T, D>, [Tensor<T, D>; 2]);
+
 pub struct MtpPrefill<T: Dtype, D: LlmBackend> {
     pending: Option<(i32, Tensor<T, D>)>,
+    scratch: Option<AlignmentScratch<T, D>>,
+    next_ids: Vec<i32>,
+    pair_positions: Vec<i32>,
 }
 impl<T: Dtype, D: LlmBackend> Default for MtpPrefill<T, D> {
     fn default() -> Self {
-        Self { pending: None }
+        Self {
+            pending: None,
+            scratch: None,
+            next_ids: Vec::new(),
+            pair_positions: Vec::new(),
+        }
     }
 }
 
@@ -26,11 +36,42 @@ pub struct PreparedMtpChunk<'a, T: Dtype, D: LlmBackend> {
 }
 impl<T: Dtype, D: LlmBackend> PreparedMtpChunk<'_, T, D> {
     pub fn commit(self) {
-        self.state.pending = Some(self.next);
+        self.state.pending = Some((self.next.0, self.next.1.clone()));
+    }
+}
+
+impl<T: Dtype, D: LlmBackend> Drop for PreparedMtpChunk<'_, T, D> {
+    fn drop(&mut self) {
+        self.state.next_ids = std::mem::take(&mut self.next_token_ids);
+        self.state.pair_positions = std::mem::take(&mut self.positions);
     }
 }
 
 impl<T: Dtype, D: LlmBackend> MtpPrefill<T, D> {
+    pub fn with_capacity(capacity: usize, dim: usize, device: &D) -> OpResult<Self> {
+        Ok(Self {
+            pending: None,
+            scratch: Some((
+                Tensor::zeros([capacity, dim], device)?,
+                [
+                    Tensor::zeros([1, dim], device)?,
+                    Tensor::zeros([1, dim], device)?,
+                ],
+            )),
+            next_ids: Vec::with_capacity(capacity),
+            pair_positions: Vec::with_capacity(capacity),
+        })
+    }
+    pub fn prepare_on(
+        &mut self,
+        ids: &[i32],
+        positions: &[i32],
+        hidden: &Tensor<T, D>,
+        scope: &D::Scope,
+    ) -> OpResult<PreparedMtpChunk<'_, T, D>> {
+        self.prepare_impl(ids, positions, hidden, Some(scope))
+    }
+
     pub fn pending(&self) -> Option<(i32, &Tensor<T, D>)> {
         self.pending.as_ref().map(|(p, h)| (*p, h))
     }
@@ -47,6 +88,16 @@ impl<T: Dtype, D: LlmBackend> MtpPrefill<T, D> {
         ids: &[i32],
         positions: &[i32],
         hidden: &Tensor<T, D>,
+    ) -> OpResult<PreparedMtpChunk<'_, T, D>> {
+        self.prepare_impl(ids, positions, hidden, None)
+    }
+
+    fn prepare_impl(
+        &mut self,
+        ids: &[i32],
+        positions: &[i32],
+        hidden: &Tensor<T, D>,
+        scope: Option<&D::Scope>,
     ) -> OpResult<PreparedMtpChunk<'_, T, D>> {
         let n = ids.len();
         let shape = hidden.shape().as_slice();
@@ -79,23 +130,44 @@ impl<T: Dtype, D: LlmBackend> MtpPrefill<T, D> {
         }
         let carry = usize::from(self.pending.is_some());
         let count = n - 1 + carry;
-        let aligned = Tensor::zeros([count, shape[1]], hidden.device())?;
-        let mut next_ids = Vec::with_capacity(count);
-        let mut pair_positions = Vec::with_capacity(count);
+        // The default constructor is retained for standalone reference callers;
+        // production creates the full capacity at startup.
+        if self.scratch.as_ref().is_none_or(|(a, _)| a.shape()[0] < n) {
+            self.scratch = Self::with_capacity(n, shape[1], hidden.device())?.scratch;
+        }
+        let (buffer, carries) = self.scratch.as_ref().unwrap();
+        if buffer.shape()[1] != shape[1] {
+            return Err(OpError::Shape("MTP alignment dimension mismatch".into()));
+        }
+        let aligned = buffer.narrow(0, 0, count)?;
+        let bank = usize::from(
+            self.pending
+                .as_ref()
+                .is_some_and(|(_, h)| h.data_ptr() == carries[0].data_ptr()),
+        );
+        let mut last = carries[bank].clone();
+        let copy = |src: &Tensor<T, D>, dst: &mut Tensor<T, D>| match scope {
+            Some(scope) => D::copy_tensor(scope, src, dst),
+            None => dst.copy_from(src),
+        };
+        let mut next_ids = std::mem::take(&mut self.next_ids);
+        let mut pair_positions = std::mem::take(&mut self.pair_positions);
+        next_ids.clear();
+        pair_positions.clear();
         if let Some((p, h)) = &self.pending {
-            aligned.narrow(0, 0, 1)?.copy_from(h)?;
+            copy(h, &mut aligned.narrow(0, 0, 1)?)?;
             next_ids.push(ids[0]);
             pair_positions.push(*p);
         }
         if n > 1 {
-            aligned
-                .narrow(0, carry, n - 1)?
-                .copy_from(&hidden.narrow(0, 0, n - 1)?)?;
+            copy(
+                &hidden.narrow(0, 0, n - 1)?,
+                &mut aligned.narrow(0, carry, n - 1)?,
+            )?;
             next_ids.extend_from_slice(&ids[1..]);
             pair_positions.extend_from_slice(&positions[..n - 1]);
         }
-        let mut last = Tensor::zeros([1, shape[1]], hidden.device())?;
-        last.copy_from(&hidden.narrow(0, n - 1, 1)?)?;
+        copy(&hidden.narrow(0, n - 1, 1)?, &mut last)?;
         Ok(PreparedMtpChunk {
             state: self,
             next: (positions[n - 1], last),
@@ -161,5 +233,33 @@ mod tests {
         assert_eq!(state.pending().unwrap().0, 1);
         state.reset();
         assert!(state.pending().is_none());
+    }
+    #[test]
+    fn startup_alignment_reuses_buffers_and_aborted_chunk_keeps_carry() {
+        let mut state = MtpPrefill::with_capacity(4, 2, &Cpu).unwrap();
+        let scope = infer_core::exec::HostScope::new(Cpu);
+        let hidden = Tensor::from_host_slice(&[1f32, 2., 3., 4.], [2, 2], &Cpu).unwrap();
+        let address = state.scratch.as_ref().unwrap().0.data_ptr();
+        let ids_address = state.next_ids.as_ptr();
+        state
+            .prepare_on(&[10, 11], &[0, 1], &hidden, &scope)
+            .unwrap()
+            .commit();
+        let carry = state.pending().unwrap().1.data_ptr();
+        let next = Tensor::from_host_slice(&[5f32, 6.], [1, 2], &Cpu).unwrap();
+        for _ in 0..2 {
+            let chunk = state.prepare_on(&[12], &[2], &next, &scope).unwrap();
+            assert_eq!(chunk.target_hidden.to_host_vec().unwrap(), [3., 4.]);
+            drop(chunk);
+            assert_eq!(state.pending().unwrap().1.data_ptr(), carry);
+            assert_eq!(state.pending().unwrap().1.to_host_vec().unwrap(), [3., 4.]);
+        }
+        state
+            .prepare_on(&[12], &[2], &next, &scope)
+            .unwrap()
+            .commit();
+        assert_eq!(state.pending().unwrap().1.to_host_vec().unwrap(), [5., 6.]);
+        assert_eq!(state.scratch.as_ref().unwrap().0.data_ptr(), address);
+        assert_eq!(state.next_ids.as_ptr(), ids_address);
     }
 }

--- a/crates/infer-worker/src/application/speculative/prefill.rs
+++ b/crates/infer-worker/src/application/speculative/prefill.rs
@@ -1,0 +1,165 @@
+//! Per-sequence text-prefill alignment for a hidden-conditioned draft head.
+//! Only the final normalized hidden row survives a completed chunk.
+use crate::domain::dtype::Dtype;
+use crate::domain::ports::backend::LlmBackend;
+use crate::domain::ports::{OpError, OpResult};
+use crate::domain::tensor::Tensor;
+
+pub struct MtpPrefill<T: Dtype, D: LlmBackend> {
+    pending: Option<(i32, Tensor<T, D>)>,
+}
+impl<T: Dtype, D: LlmBackend> Default for MtpPrefill<T, D> {
+    fn default() -> Self {
+        Self { pending: None }
+    }
+}
+
+/// Dropping an uncommitted chunk preserves the previous alignment state.
+/// Commit only after the corresponding head execution succeeds. KV recovery
+/// after an execution error is the caller's responsibility.
+pub struct PreparedMtpChunk<'a, T: Dtype, D: LlmBackend> {
+    state: &'a mut MtpPrefill<T, D>,
+    next: (i32, Tensor<T, D>),
+    pub next_token_ids: Vec<i32>,
+    pub positions: Vec<i32>,
+    pub target_hidden: Tensor<T, D>,
+}
+impl<T: Dtype, D: LlmBackend> PreparedMtpChunk<'_, T, D> {
+    pub fn commit(self) {
+        self.state.pending = Some(self.next);
+    }
+}
+
+impl<T: Dtype, D: LlmBackend> MtpPrefill<T, D> {
+    pub fn pending(&self) -> Option<(i32, &Tensor<T, D>)> {
+        self.pending.as_ref().map(|(p, h)| (*p, h))
+    }
+    pub fn reset(&mut self) {
+        self.pending = None;
+    }
+
+    /// Hidden rows must be final-normalized target outputs for these tokens.
+    /// A first singleton chunk produces zero pairs and must skip head execution.
+    /// Copies run on the tensor device's default stream. The caller must make
+    /// target outputs ready on that stream before preparing the chunk.
+    pub fn prepare(
+        &mut self,
+        ids: &[i32],
+        positions: &[i32],
+        hidden: &Tensor<T, D>,
+    ) -> OpResult<PreparedMtpChunk<'_, T, D>> {
+        let n = ids.len();
+        let shape = hidden.shape().as_slice();
+        if n == 0
+            || positions.len() != n
+            || shape.len() != 2
+            || shape[0] != n
+            || shape[1] == 0
+            || !hidden.is_contiguous()
+            || positions[0] < 0
+            || positions
+                .windows(2)
+                .any(|p| p[0].checked_add(1) != Some(p[1]))
+        {
+            return Err(OpError::Shape(
+                "MTP prefill requires nonempty consecutive text positions and [tokens, dim] hidden"
+                    .into(),
+            ));
+        }
+        if let Some((p, h)) = &self.pending {
+            if p.checked_add(1) != Some(positions[0]) || h.shape().as_slice() != [1, shape[1]] {
+                return Err(OpError::Shape(
+                    "MTP prefill chunk does not follow pending hidden".into(),
+                ));
+            }
+        } else if positions[0] != 0 {
+            return Err(OpError::Shape(
+                "MTP prefill must start at position zero".into(),
+            ));
+        }
+        let carry = usize::from(self.pending.is_some());
+        let count = n - 1 + carry;
+        let aligned = Tensor::zeros([count, shape[1]], hidden.device())?;
+        let mut next_ids = Vec::with_capacity(count);
+        let mut pair_positions = Vec::with_capacity(count);
+        if let Some((p, h)) = &self.pending {
+            aligned.narrow(0, 0, 1)?.copy_from(h)?;
+            next_ids.push(ids[0]);
+            pair_positions.push(*p);
+        }
+        if n > 1 {
+            aligned
+                .narrow(0, carry, n - 1)?
+                .copy_from(&hidden.narrow(0, 0, n - 1)?)?;
+            next_ids.extend_from_slice(&ids[1..]);
+            pair_positions.extend_from_slice(&positions[..n - 1]);
+        }
+        let mut last = Tensor::zeros([1, shape[1]], hidden.device())?;
+        last.copy_from(&hidden.narrow(0, n - 1, 1)?)?;
+        Ok(PreparedMtpChunk {
+            state: self,
+            next: (positions[n - 1], last),
+            next_token_ids: next_ids,
+            positions: pair_positions,
+            target_hidden: aligned,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::infrastructure::cpu::Cpu;
+    #[test]
+    fn every_chunk_partition_preserves_shift_and_hidden_positions() {
+        let ids = [10, 11, 12, 13, 14];
+        let all =
+            Tensor::from_host_slice(&(0..15).map(|x| x as f32).collect::<Vec<_>>(), [5, 3], &Cpu)
+                .unwrap();
+        for cuts in 0..16 {
+            let mut state = MtpPrefill::default();
+            let (mut tokens, mut pos, mut hidden) = (Vec::new(), Vec::new(), Vec::new());
+            let mut start = 0;
+            for end in 1..=5 {
+                if end < 5 && cuts & (1 << (end - 1)) == 0 {
+                    continue;
+                }
+                let ps: Vec<_> = (start as i32..end as i32).collect();
+                let chunk = state
+                    .prepare(
+                        &ids[start..end],
+                        &ps,
+                        &all.narrow(0, start, end - start).unwrap(),
+                    )
+                    .unwrap();
+                tokens.extend_from_slice(&chunk.next_token_ids);
+                pos.extend_from_slice(&chunk.positions);
+                hidden.extend(chunk.target_hidden.to_host_vec().unwrap());
+                chunk.commit();
+                start = end;
+            }
+            assert_eq!(tokens, ids[1..]);
+            assert_eq!(pos, [0, 1, 2, 3]);
+            assert_eq!(hidden, (0..12).map(|x| x as f32).collect::<Vec<_>>());
+            let (p, h) = state.pending().unwrap();
+            assert_eq!(p, 4);
+            assert_eq!(h.to_host_vec().unwrap(), [12., 13., 14.]);
+        }
+    }
+    #[test]
+    fn failed_chunk_preserves_owned_carry_and_can_retry() {
+        let mut state = MtpPrefill::default();
+        let mut h = Tensor::from_host_slice(&[1f32, 2.], [1, 2], &Cpu).unwrap();
+        state.prepare(&[10], &[0], &h).unwrap().commit();
+        h.copy_from(&Tensor::from_host_slice(&[8f32, 9.], [1, 2], &Cpu).unwrap())
+            .unwrap();
+        assert_eq!(state.pending().unwrap().1.to_host_vec().unwrap(), [1., 2.]);
+        drop(state.prepare(&[11], &[1], &h).unwrap());
+        assert_eq!(state.pending().unwrap().0, 0);
+        assert!(state.prepare(&[12], &[2], &h).is_err());
+        state.prepare(&[11], &[1], &h).unwrap().commit();
+        assert_eq!(state.pending().unwrap().0, 1);
+        state.reset();
+        assert!(state.pending().is_none());
+    }
+}

--- a/crates/infer-worker/src/application/speculative/serving.rs
+++ b/crates/infer-worker/src/application/speculative/serving.rs
@@ -5,7 +5,7 @@ use crate::application::serve_execution::{ServingExecution, ServingStep};
 use crate::application::worker_scheduler::handle_eager_prefill;
 use crate::components::mtp::MtpHead;
 use crate::domain::model::DecoderReadout;
-use crate::domain::plan::{SeqStep, StepRequest, StopCriteria};
+use crate::domain::plan::StepRequest;
 use crate::domain::ports::{OpError, OpResult};
 use crate::infrastructure::cuda::Cuda;
 use half::bf16;
@@ -15,6 +15,8 @@ pub struct MtpServing<H: DecoderReadout<bf16, Cuda>> {
     proposer: MtpProposer<bf16, Cuda, H>,
     owner: Option<u64>,
     draft_tokens: usize,
+    request: StepRequest,
+    target_hidden: crate::domain::tensor::Tensor<bf16, Cuda>,
 }
 
 impl<H: DecoderReadout<bf16, Cuda>> MtpServing<H> {
@@ -30,7 +32,13 @@ impl<H: DecoderReadout<bf16, Cuda>> MtpServing<H> {
                 "MTP serving draft width must fit K+1 target rows".into(),
             ));
         }
+        let target_hidden =
+            crate::domain::tensor::Tensor::zeros([max_step_tokens, head.dims().dim], device)?;
+        let mut request = StepRequest::workspace(1, draft_tokens + 1, max_context);
+        request.draft_tokens.push(Vec::with_capacity(draft_tokens));
         Ok(Self {
+            request,
+            target_hidden,
             proposer: MtpProposer::new(
                 head,
                 max_context,
@@ -86,18 +94,18 @@ impl<H: DecoderReadout<bf16, Cuda>> MtpServing<H> {
             ctx.allocator,
             ctx.eos_ids,
             |runner, req| {
-                let mut target = runner.step_with_hidden(req)?;
+                let mut output = runner.step_with_hidden_into(req, &mut self.target_hidden)?;
                 let seq = &req.seqs[0];
                 self.proposer.observe(
                     &seq.input_ids,
                     seq.kv_write_start as usize,
-                    &target.normalized_hidden,
+                    &self.target_hidden.narrow(0, 0, seq.input_ids.len())?,
                     &runner.scope,
                 )?;
                 if seq.kv_len_after as usize >= runner.max_seq_len {
-                    target.output.finished[0] = true;
+                    output.finished[0] = true;
                 }
-                Ok(target.output)
+                Ok(output)
             },
         )?;
         ctx.data
@@ -133,51 +141,57 @@ impl<H: DecoderReadout<bf16, Cuda>> MtpServing<H> {
             let started = std::time::Instant::now();
             let drafts = self.proposer.draft(seq.last_token, k, &ctx.runner.scope)?;
             let drafted = started.elapsed();
-            let mut input = vec![seq.last_token];
-            input.extend_from_slice(&drafts);
-            let mut table = seq.block_table.clone();
-            table.extend_from_slice(lease.as_slice());
-            let req = StepRequest {
-                seqs: vec![SeqStep {
-                    sequence_id: id,
-                    input_ids: input.clone(),
-                    positions: (seq.kv_len as i32..(seq.kv_len + input.len()) as i32).collect(),
-                    kv_write_start: seq.kv_len as i32,
-                    kv_len_after: (seq.kv_len + input.len()) as i32,
-                    block_table: table,
-                }],
-                sampling: vec![seq.sampling],
-                draft_tokens: vec![drafts],
-                stop: StopCriteria {
-                    eos_ids: ctx.eos_ids.to_vec(),
-                    generated_counts: vec![seq.generated_count as u32],
-                    max_tokens: vec![seq.max_tokens as u32],
-                    ignore_eos: vec![seq.ignore_eos],
-                },
-            };
-            let mut target = ctx.runner.step_with_hidden(&req)?;
+            let req = &mut self.request;
+            let staged = &mut req.seqs[0];
+            staged.sequence_id = id;
+            staged.input_ids.clear();
+            staged.input_ids.push(seq.last_token);
+            staged.input_ids.extend_from_slice(&drafts);
+            staged.positions.clear();
+            staged
+                .positions
+                .extend(seq.kv_len as i32..(seq.kv_len + k + 1) as i32);
+            staged.kv_write_start = seq.kv_len as i32;
+            staged.kv_len_after = (seq.kv_len + k + 1) as i32;
+            staged.block_table.clone_from(&seq.block_table);
+            staged.block_table.extend_from_slice(lease.as_slice());
+            req.sampling.clear();
+            req.sampling.push(seq.sampling);
+            req.draft_tokens[0].clear();
+            req.draft_tokens[0].extend_from_slice(&drafts);
+            req.stop.eos_ids.clear();
+            req.stop.eos_ids.extend_from_slice(ctx.eos_ids);
+            req.stop.generated_counts.clear();
+            req.stop.generated_counts.push(seq.generated_count as u32);
+            req.stop.max_tokens.clear();
+            req.stop.max_tokens.push(seq.max_tokens as u32);
+            req.stop.ignore_eos.clear();
+            req.stop.ignore_eos.push(seq.ignore_eos);
+            let mut output = ctx
+                .runner
+                .step_with_hidden_into(req, &mut self.target_hidden)?;
             let verified = started.elapsed();
-            let kept = target.output.materialized_tokens[0] as usize;
+            let kept = output.materialized_tokens[0] as usize;
             self.proposer.observe(
-                &input[..kept],
+                &req.seqs[0].input_ids[..kept],
                 seq.kv_len,
-                &target.normalized_hidden,
+                &self.target_hidden.narrow(0, 0, kept)?,
                 &ctx.runner.scope,
             )?;
             if seq.kv_len + kept >= ctx.runner.max_seq_len {
-                target.output.finished[0] = true;
+                output.finished[0] = true;
             }
             tracing::debug!(
                 sequence_id = id,
                 proposed = k,
-                accepted = target.output.accepted_drafts.as_ref().unwrap()[0],
-                emitted = target.output.tokens[0].len(),
+                accepted = output.accepted_drafts.as_ref().unwrap()[0],
+                emitted = output.tokens[0].len(),
                 draft_ms = drafted.as_secs_f64() * 1e3,
                 verify_ms = (verified - drafted).as_secs_f64() * 1e3,
                 catchup_ms = (started.elapsed() - verified).as_secs_f64() * 1e3,
                 "MTP round"
             );
-            Ok(target.output)
+            Ok(output)
         })();
         let output = match result {
             Ok(out) => out,

--- a/crates/infer-worker/src/application/speculative/serving.rs
+++ b/crates/infer-worker/src/application/speculative/serving.rs
@@ -1,0 +1,251 @@
+//! Explicit MTP adapter for the existing worker control and data planes.
+use super::{MtpProposer, commit::commit_decode, validate_sampling};
+use crate::application::decode_common::send_step_error;
+use crate::application::serve_execution::{ServingExecution, ServingStep};
+use crate::application::worker_scheduler::handle_eager_prefill;
+use crate::components::mtp::MtpHead;
+use crate::domain::model::DecoderReadout;
+use crate::domain::plan::{SeqStep, StepRequest, StopCriteria};
+use crate::domain::ports::{OpError, OpResult};
+use crate::infrastructure::cuda::Cuda;
+use half::bf16;
+use infer_protocol::scheduler_to_worker_data::PrefillBatchCmd;
+
+pub struct MtpServing<H: DecoderReadout<bf16, Cuda>> {
+    proposer: MtpProposer<bf16, Cuda, H>,
+    owner: Option<u64>,
+    draft_tokens: usize,
+}
+
+impl<H: DecoderReadout<bf16, Cuda>> MtpServing<H> {
+    pub fn new(
+        head: MtpHead<bf16, Cuda, H>,
+        max_context: usize,
+        max_step_tokens: usize,
+        draft_tokens: usize,
+        device: &Cuda,
+    ) -> OpResult<Self> {
+        if draft_tokens == 0 || draft_tokens >= max_step_tokens {
+            return Err(OpError::Shape(
+                "MTP serving draft width must fit K+1 target rows".into(),
+            ));
+        }
+        Ok(Self {
+            proposer: MtpProposer::new(
+                head,
+                max_context,
+                max_step_tokens.min(max_context),
+                device,
+            )?,
+            owner: None,
+            draft_tokens,
+        })
+    }
+
+    fn prefill<M: DecoderReadout<bf16, Cuda>>(
+        &mut self,
+        ctx: &mut ServingStep<'_, M>,
+        cmd: &PrefillBatchCmd,
+    ) -> OpResult<()> {
+        cmd.validate(ctx.runner.cap_num_tokens, 1)
+            .map_err(|e| OpError::Shape(e.to_string()))?;
+        let seg = &cmd.segments[0];
+        if seg.has_multimodal
+            || seg.multimodal.is_some()
+            || seg.prefix_hint.as_ref().is_some_and(|p| !p.is_empty())
+        {
+            return Err(OpError::unsupported(
+                "MTP serving",
+                "multimodal inputs or prefix-cache hits",
+            ));
+        }
+        let params = crate::domain::ports::SamplingParams {
+            temperature: seg.sampling_params.temperature,
+            top_k: seg.sampling_params.top_k.max(0) as u32,
+            top_p: seg.sampling_params.top_p,
+            ..Default::default()
+        };
+        validate_sampling(&[params], 1)?;
+        if seg.segment_start == 0 {
+            if ctx.prefilling.contains_key(&seg.sequence_id) {
+                return Err(OpError::Shape("duplicate MTP initial prefill".into()));
+            }
+            ctx.runner.release_sequence(seg.sequence_id);
+            self.proposer.reset();
+            self.owner = Some(seg.sequence_id);
+        } else if self.owner != Some(seg.sequence_id) {
+            return Err(OpError::Shape(
+                "MTP prefill continuation has no draft history".into(),
+            ));
+        }
+        let wire = handle_eager_prefill(
+            cmd,
+            ctx.runner,
+            ctx.active,
+            ctx.prefilling,
+            ctx.allocator,
+            ctx.eos_ids,
+            |runner, req| {
+                let mut target = runner.step_with_hidden(req)?;
+                let seq = &req.seqs[0];
+                self.proposer.observe(
+                    &seq.input_ids,
+                    seq.kv_write_start as usize,
+                    &target.normalized_hidden,
+                    &runner.scope,
+                )?;
+                if seq.kv_len_after as usize >= runner.max_seq_len {
+                    target.output.finished[0] = true;
+                }
+                Ok(target.output)
+            },
+        )?;
+        ctx.data
+            .send_step_output(&wire)
+            .map_err(|e| OpError::Kernel(e.to_string()))
+    }
+
+    fn decode<M: DecoderReadout<bf16, Cuda>>(
+        &mut self,
+        ctx: &mut ServingStep<'_, M>,
+        id: u64,
+    ) -> OpResult<()> {
+        let seq = &ctx.active[&id];
+        if self.owner != Some(id) || self.proposer.committed_len() + 1 != seq.kv_len {
+            return Err(OpError::Shape("MTP target/draft history mismatch".into()));
+        }
+        validate_sampling(std::slice::from_ref(&seq.sampling), 1)?;
+        let remaining = seq.max_tokens.saturating_sub(seq.generated_count);
+        let capacity = ctx.runner.max_seq_len.saturating_sub(seq.kv_len);
+        if remaining == 0 || capacity == 0 {
+            return Err(OpError::Shape("MTP decode has exhausted its budget".into()));
+        }
+        let k = self
+            .draft_tokens
+            .min(remaining - 1)
+            .min(capacity - 1)
+            .min(ctx.allocator.total_free().saturating_sub(1) as usize);
+        let mut lease = ctx
+            .allocator
+            .lease((k + 1) as u32)
+            .map_err(|e| OpError::Shape(e.to_string()))?;
+        let result = (|| {
+            let started = std::time::Instant::now();
+            let drafts = self.proposer.draft(seq.last_token, k, &ctx.runner.scope)?;
+            let drafted = started.elapsed();
+            let mut input = vec![seq.last_token];
+            input.extend_from_slice(&drafts);
+            let mut table = seq.block_table.clone();
+            table.extend_from_slice(lease.as_slice());
+            let req = StepRequest {
+                seqs: vec![SeqStep {
+                    sequence_id: id,
+                    input_ids: input.clone(),
+                    positions: (seq.kv_len as i32..(seq.kv_len + input.len()) as i32).collect(),
+                    kv_write_start: seq.kv_len as i32,
+                    kv_len_after: (seq.kv_len + input.len()) as i32,
+                    block_table: table,
+                }],
+                sampling: vec![seq.sampling],
+                draft_tokens: vec![drafts],
+                stop: StopCriteria {
+                    eos_ids: ctx.eos_ids.to_vec(),
+                    generated_counts: vec![seq.generated_count as u32],
+                    max_tokens: vec![seq.max_tokens as u32],
+                    ignore_eos: vec![seq.ignore_eos],
+                },
+            };
+            let mut target = ctx.runner.step_with_hidden(&req)?;
+            let verified = started.elapsed();
+            let kept = target.output.materialized_tokens[0] as usize;
+            self.proposer.observe(
+                &input[..kept],
+                seq.kv_len,
+                &target.normalized_hidden,
+                &ctx.runner.scope,
+            )?;
+            if seq.kv_len + kept >= ctx.runner.max_seq_len {
+                target.output.finished[0] = true;
+            }
+            tracing::debug!(
+                sequence_id = id,
+                proposed = k,
+                accepted = target.output.accepted_drafts.as_ref().unwrap()[0],
+                emitted = target.output.tokens[0].len(),
+                draft_ms = drafted.as_secs_f64() * 1e3,
+                verify_ms = (verified - drafted).as_secs_f64() * 1e3,
+                catchup_ms = (started.elapsed() - verified).as_secs_f64() * 1e3,
+                "MTP round"
+            );
+            Ok(target.output)
+        })();
+        let output = match result {
+            Ok(out) => out,
+            Err(e) => {
+                lease.release(ctx.allocator);
+                return Err(e);
+            }
+        };
+        let wire = commit_decode(ctx.active, ctx.allocator, id, lease.take(), output)?;
+        ctx.data
+            .send_step_output(&wire)
+            .map_err(|e| OpError::Kernel(e.to_string()))
+    }
+}
+
+impl<M: DecoderReadout<bf16, Cuda>, H: DecoderReadout<bf16, Cuda>> ServingExecution<M>
+    for MtpServing<H>
+{
+    const SPECULATIVE: bool = true;
+    fn step(&mut self, mut ctx: ServingStep<'_, M>) -> OpResult<()> {
+        if ctx.runner.cap_batch != 1 || ctx.active.len() + ctx.prefilling.len() > 1 {
+            return Err(OpError::Shape(
+                "MTP serving requires one active request".into(),
+            ));
+        }
+        if self
+            .owner
+            .is_some_and(|id| !ctx.active.contains_key(&id) && !ctx.prefilling.contains_key(&id))
+        {
+            self.proposer.reset();
+            self.owner = None;
+        }
+        let (ids, result) = if let Some(&id) = ctx.active.keys().next() {
+            (vec![id], self.decode(&mut ctx, id))
+        } else if let Some(index) = ctx.prefills.iter().position(|cmd| {
+            ctx.prefilling.is_empty()
+                || cmd
+                    .segments
+                    .iter()
+                    .any(|s| ctx.prefilling.contains_key(&s.sequence_id))
+        }) {
+            let cmd = ctx.prefills.remove(index);
+            let ids = cmd
+                .segments
+                .iter()
+                .map(|s| s.sequence_id)
+                .collect::<Vec<_>>();
+            (ids, self.prefill(&mut ctx, &cmd))
+        } else {
+            return Ok(());
+        };
+        if let Err(error) = result {
+            if error.is_fatal() {
+                return Err(error);
+            }
+            for &id in &ids {
+                if let Some(seq) = ctx.active.remove(&id) {
+                    ctx.allocator.release_owned(&seq.block_table, false);
+                }
+                if let Some(seq) = ctx.prefilling.remove(&id) {
+                    ctx.allocator.release_owned(&seq.block_table, false);
+                }
+                ctx.runner.release_sequence(id);
+            }
+            self.proposer.reset();
+            self.owner = None;
+            send_step_error(ctx.control, ids, error.to_string());
+        }
+        Ok(())
+    }
+}

--- a/crates/infer-worker/src/application/speculative/serving.rs
+++ b/crates/infer-worker/src/application/speculative/serving.rs
@@ -1,6 +1,7 @@
 //! Explicit MTP adapter for the existing worker control and data planes.
 use super::{MtpProposer, commit::commit_decode, validate_sampling};
 use crate::application::decode_common::send_step_error;
+use crate::application::execution::{ExecutionPlan, Phase, WorkspaceUse};
 use crate::application::serve_execution::{ServingExecution, ServingStep};
 use crate::application::worker_scheduler::handle_eager_prefill;
 use crate::components::mtp::MtpHead;
@@ -205,7 +206,16 @@ impl<H: DecoderReadout<bf16, Cuda>> MtpServing<H> {
                 return Err(e);
             }
         };
-        let wire = commit_decode(ctx.active, ctx.allocator, id, lease.take(), output)?;
+        let accepted = output.accepted_drafts.as_ref().unwrap()[0] as usize;
+        let emitted = output.tokens[0].len();
+        let materialized = output.materialized_tokens[0] as usize;
+        let wire = ExecutionPlan::eager(Phase::Commit, 1, materialized, WorkspaceUse::Runtime)
+            .execute(&ctx.runner.execution_metrics, |_| {
+                commit_decode(ctx.active, ctx.allocator, id, lease.take(), output)
+            })?;
+        ctx.runner
+            .execution_metrics
+            .committed(k, accepted, emitted, materialized);
         ctx.data
             .send_step_output(&wire)
             .map_err(|e| OpError::Kernel(e.to_string()))
@@ -216,6 +226,12 @@ impl<M: DecoderReadout<bf16, Cuda>, H: DecoderReadout<bf16, Cuda>> ServingExecut
     for MtpServing<H>
 {
     const SPECULATIVE: bool = true;
+    fn prepare(
+        &mut self,
+        runner: &crate::application::runtime::Runtime<bf16, Cuda, M>,
+    ) -> OpResult<()> {
+        self.proposer.prepare_metrics(&runner.scope)
+    }
     fn step(&mut self, mut ctx: ServingStep<'_, M>) -> OpResult<()> {
         if ctx.runner.cap_batch != 1 || ctx.active.len() + ctx.prefilling.len() > 1 {
             return Err(OpError::Shape(

--- a/crates/infer-worker/src/application/speculative/serving.rs
+++ b/crates/infer-worker/src/application/speculative/serving.rs
@@ -139,7 +139,9 @@ impl<H: DecoderReadout<bf16, Cuda>> MtpServing<H> {
             .map_err(|e| OpError::Shape(e.to_string()))?;
         let result = (|| {
             let started = std::time::Instant::now();
-            let drafts = self.proposer.draft(seq.last_token, k, &ctx.runner.scope)?;
+            let (drafts, device_input) =
+                self.proposer
+                    .draft_with_device(seq.last_token, k, &ctx.runner.scope)?;
             let drafted = started.elapsed();
             let req = &mut self.request;
             let staged = &mut req.seqs[0];
@@ -167,16 +169,19 @@ impl<H: DecoderReadout<bf16, Cuda>> MtpServing<H> {
             req.stop.max_tokens.push(seq.max_tokens as u32);
             req.stop.ignore_eos.clear();
             req.stop.ignore_eos.push(seq.ignore_eos);
-            let mut output = ctx
-                .runner
-                .step_with_hidden_into(req, &mut self.target_hidden)?;
+            let mut output = ctx.runner.step_with_hidden_input(
+                req,
+                &mut self.target_hidden,
+                Some(&device_input),
+            )?;
             let verified = started.elapsed();
             let kept = output.materialized_tokens[0] as usize;
-            self.proposer.observe(
+            self.proposer.observe_with_input(
                 &req.seqs[0].input_ids[..kept],
                 seq.kv_len,
                 &self.target_hidden.narrow(0, 0, kept)?,
                 &ctx.runner.scope,
+                Some(&device_input.narrow(0, 0, kept)?),
             )?;
             if seq.kv_len + kept >= ctx.runner.max_seq_len {
                 output.finished[0] = true;

--- a/crates/infer-worker/src/application/speculative/session.rs
+++ b/crates/infer-worker/src/application/speculative/session.rs
@@ -78,6 +78,7 @@ impl<T: Dtype, D: LlmBackend, M: DecoderReadout<T, D>, H: DecoderReadout<T, D>>
             limits.max_step_tokens,
             scope.device(),
         )?;
+        proposer.prepare_metrics(&scope)?;
         let block_size = 16;
         let num_blocks = limits.max_context.div_ceil(block_size);
         let target_hidden = crate::domain::tensor::Tensor::zeros(
@@ -220,6 +221,12 @@ impl<T: Dtype, D: LlmBackend, M: DecoderReadout<T, D>, H: DecoderReadout<T, D>>
             self.pending = tokens.last().copied();
             self.finished = output.finished[0] || self.len >= self.limits.max_context;
             debug_assert_eq!(self.proposer.committed_len() + 1, self.len);
+            self.target.execution_metrics.committed(
+                k,
+                output.accepted_drafts.as_ref().unwrap()[0] as usize,
+                tokens.len(),
+                retained,
+            );
             Ok(MtpStep {
                 tokens,
                 proposed: k,

--- a/crates/infer-worker/src/application/speculative/session.rs
+++ b/crates/infer-worker/src/application/speculative/session.rs
@@ -42,6 +42,7 @@ pub struct MtpSession<T: Dtype, D: LlmBackend, M: DecoderReadout<T, D>, H: Decod
     generated: u32,
     finished: bool,
     poisoned: bool,
+    target_hidden: crate::domain::tensor::Tensor<T, D>,
 }
 
 impl<T: Dtype, D: LlmBackend, M: DecoderReadout<T, D>, H: DecoderReadout<T, D>>
@@ -79,7 +80,11 @@ impl<T: Dtype, D: LlmBackend, M: DecoderReadout<T, D>, H: DecoderReadout<T, D>>
         )?;
         let block_size = 16;
         let num_blocks = limits.max_context.div_ceil(block_size);
-        let target = Runtime::new(
+        let target_hidden = crate::domain::tensor::Tensor::zeros(
+            [limits.max_step_tokens, model.dims().dim],
+            scope.device(),
+        )?;
+        let mut target = Runtime::new(
             model,
             scope,
             Box::new(GreedySampler),
@@ -91,7 +96,9 @@ impl<T: Dtype, D: LlmBackend, M: DecoderReadout<T, D>, H: DecoderReadout<T, D>>
             1,
             vec![],
         )?;
+        target.prepare_speculative()?;
         Ok(Self {
+            target_hidden,
             target,
             proposer,
             blocks: (0..num_blocks as u32).collect(),
@@ -143,15 +150,17 @@ impl<T: Dtype, D: LlmBackend, M: DecoderReadout<T, D>, H: DecoderReadout<T, D>>
             let mut next = 0;
             for ids in prompt.chunks(self.limits.max_step_tokens) {
                 let request = self.request(ids, vec![]);
-                let target = self.target.step_with_hidden(&request)?;
+                let output = self
+                    .target
+                    .step_with_hidden_into(&request, &mut self.target_hidden)?;
                 self.proposer.observe(
                     ids,
                     self.len,
-                    &target.normalized_hidden,
+                    &self.target_hidden.narrow(0, 0, ids.len())?,
                     &self.target.scope,
                 )?;
                 self.len += ids.len();
-                next = target.output.tokens[0][0].token_id;
+                next = output.tokens[0][0].token_id;
             }
             self.pending = Some(next);
             self.generated = 1;
@@ -188,29 +197,30 @@ impl<T: Dtype, D: LlmBackend, M: DecoderReadout<T, D>, H: DecoderReadout<T, D>>
             let mut ids = Vec::with_capacity(k + 1);
             ids.push(self.pending.unwrap());
             ids.extend_from_slice(&drafts);
-            let target = self
+            let req = self.request(&ids, vec![drafts]);
+            let output = self
                 .target
-                .step_with_hidden(&self.request(&ids, vec![drafts]))?;
-            let retained = target.output.materialized_tokens[0] as usize;
+                .step_with_hidden_into(&req, &mut self.target_hidden)?;
+            let retained = output.materialized_tokens[0] as usize;
             self.proposer.observe(
                 &ids[..retained],
                 self.len,
-                &target.normalized_hidden,
+                &self.target_hidden.narrow(0, 0, retained)?,
                 &self.target.scope,
             )?;
-            let tokens = target.output.tokens[0]
+            let tokens = output.tokens[0]
                 .iter()
                 .map(|t| t.token_id)
                 .collect::<Vec<_>>();
             self.len += retained;
             self.generated += tokens.len() as u32;
             self.pending = tokens.last().copied();
-            self.finished = target.output.finished[0] || self.len >= self.limits.max_context;
+            self.finished = output.finished[0] || self.len >= self.limits.max_context;
             debug_assert_eq!(self.proposer.committed_len() + 1, self.len);
             Ok(MtpStep {
                 tokens,
                 proposed: k,
-                accepted: target.output.accepted_drafts.as_ref().unwrap()[0] as usize,
+                accepted: output.accepted_drafts.as_ref().unwrap()[0] as usize,
                 finished: self.finished,
             })
         })();

--- a/crates/infer-worker/src/application/speculative/session.rs
+++ b/crates/infer-worker/src/application/speculative/session.rs
@@ -191,22 +191,25 @@ impl<T: Dtype, D: LlmBackend, M: DecoderReadout<T, D>, H: DecoderReadout<T, D>>
                 .draft_tokens
                 .min(available - 1)
                 .min(capacity - 1);
-            let drafts = self
-                .proposer
-                .draft(self.pending.unwrap(), k, &self.target.scope)?;
+            let (drafts, device_input) =
+                self.proposer
+                    .draft_with_device(self.pending.unwrap(), k, &self.target.scope)?;
             let mut ids = Vec::with_capacity(k + 1);
             ids.push(self.pending.unwrap());
             ids.extend_from_slice(&drafts);
             let req = self.request(&ids, vec![drafts]);
-            let output = self
-                .target
-                .step_with_hidden_into(&req, &mut self.target_hidden)?;
+            let output = self.target.step_with_hidden_input(
+                &req,
+                &mut self.target_hidden,
+                Some(&device_input),
+            )?;
             let retained = output.materialized_tokens[0] as usize;
-            self.proposer.observe(
+            self.proposer.observe_with_input(
                 &ids[..retained],
                 self.len,
                 &self.target_hidden.narrow(0, 0, retained)?,
                 &self.target.scope,
+                Some(&device_input.narrow(0, 0, retained)?),
             )?;
             let tokens = output.tokens[0]
                 .iter()

--- a/crates/infer-worker/src/application/speculative/session.rs
+++ b/crates/infer-worker/src/application/speculative/session.rs
@@ -1,0 +1,248 @@
+//! Single-sequence eager reference engine. Owns both caches and commits a round
+//! only after target verification, recurrent recovery, and MTP catch-up succeed.
+use super::MtpProposer;
+use crate::application::runtime::Runtime;
+use crate::application::sampler_stack::GreedySampler;
+use crate::components::mtp::MtpHead;
+use crate::domain::dtype::Dtype;
+use crate::domain::exec::ExecScope;
+use crate::domain::model::DecoderReadout;
+use crate::domain::plan::{SeqStep, StepRequest, StopCriteria};
+use crate::domain::ports::backend::LlmBackend;
+use crate::domain::ports::{OpError, OpResult};
+
+#[derive(Clone, Debug)]
+pub struct MtpLimits {
+    pub max_context: usize,
+    pub max_step_tokens: usize,
+    pub max_output_tokens: u32,
+    pub draft_tokens: usize,
+    pub eos_ids: Vec<i32>,
+}
+
+#[derive(Debug)]
+pub struct MtpStep {
+    pub tokens: Vec<i32>,
+    pub proposed: usize,
+    /// Consecutive matching drafts before EOS truncation, not a KV increment.
+    pub accepted: usize,
+    pub finished: bool,
+}
+
+/// Static dispatch for both the target and head. This engine is deliberately
+/// explicit: constructing a normal Runtime never loads or enables speculation.
+/// It owns a dedicated single-request KV allocation, not a serving scheduler lease.
+pub struct MtpSession<T: Dtype, D: LlmBackend, M: DecoderReadout<T, D>, H: DecoderReadout<T, D>> {
+    target: Runtime<T, D, M>,
+    proposer: MtpProposer<T, D, H>,
+    limits: MtpLimits,
+    blocks: Vec<u32>,
+    len: usize,
+    pending: Option<i32>,
+    generated: u32,
+    finished: bool,
+    poisoned: bool,
+}
+
+impl<T: Dtype, D: LlmBackend, M: DecoderReadout<T, D>, H: DecoderReadout<T, D>>
+    MtpSession<T, D, M, H>
+{
+    pub fn new(
+        model: M,
+        head: MtpHead<T, D, H>,
+        scope: D::Scope,
+        limits: MtpLimits,
+    ) -> OpResult<Self> {
+        if limits.max_context == 0
+            || limits.max_context > i32::MAX as usize
+            || limits.max_step_tokens == 0
+            || limits.max_step_tokens > limits.max_context
+            || limits.draft_tokens >= limits.max_step_tokens
+            || limits.max_output_tokens == 0
+            || model.dims().dim != head.dims().dim
+            || model.dims().vocab_size != head.dims().vocab_size
+            || limits
+                .eos_ids
+                .iter()
+                .any(|&id| id < 0 || id as usize >= model.dims().vocab_size)
+            || scope.topology().tp.size != 1
+        {
+            return Err(OpError::Shape(
+                "invalid MTP session limits or model dimensions".into(),
+            ));
+        }
+        let proposer = MtpProposer::new(
+            head,
+            limits.max_context,
+            limits.max_step_tokens,
+            scope.device(),
+        )?;
+        let block_size = 16;
+        let num_blocks = limits.max_context.div_ceil(block_size);
+        let target = Runtime::new(
+            model,
+            scope,
+            Box::new(GreedySampler),
+            num_blocks,
+            block_size,
+            num_blocks,
+            limits.max_context,
+            limits.max_step_tokens,
+            1,
+            vec![],
+        )?;
+        Ok(Self {
+            target,
+            proposer,
+            blocks: (0..num_blocks as u32).collect(),
+            limits,
+            len: 0,
+            pending: None,
+            generated: 0,
+            finished: false,
+            poisoned: false,
+        })
+    }
+
+    pub fn cached_tokens(&self) -> usize {
+        self.len
+    }
+    pub fn draft_cached_tokens(&self) -> usize {
+        self.proposer.committed_len()
+    }
+
+    /// Clear ownership before reusing this engine for another prompt. Old KV
+    /// bytes are unreachable at length zero and are overwritten during prefill.
+    pub fn reset(&mut self) -> OpResult<()> {
+        self.target.scope.synchronize()?;
+        self.target.release_sequence(0);
+        self.proposer.reset();
+        self.len = 0;
+        self.pending = None;
+        self.generated = 0;
+        self.finished = false;
+        self.poisoned = false;
+        Ok(())
+    }
+
+    pub fn prefill(&mut self, prompt: &[i32]) -> OpResult<MtpStep> {
+        if self.poisoned
+            || self.pending.is_some()
+            || self.len != 0
+            || prompt.is_empty()
+            || prompt.len() > self.limits.max_context
+            || prompt
+                .iter()
+                .any(|&id| id < 0 || id as usize >= self.target.dims.vocab_size)
+        {
+            return Err(OpError::Shape(
+                "MTP prefill requires a fresh session and valid prompt".into(),
+            ));
+        }
+        let result = (|| {
+            let mut next = 0;
+            for ids in prompt.chunks(self.limits.max_step_tokens) {
+                let request = self.request(ids, vec![]);
+                let target = self.target.step_with_hidden(&request)?;
+                self.proposer.observe(
+                    ids,
+                    self.len,
+                    &target.normalized_hidden,
+                    &self.target.scope,
+                )?;
+                self.len += ids.len();
+                next = target.output.tokens[0][0].token_id;
+            }
+            self.pending = Some(next);
+            self.generated = 1;
+            self.finished = self.limits.eos_ids.contains(&next)
+                || self.generated >= self.limits.max_output_tokens
+                || self.len >= self.limits.max_context;
+            Ok(MtpStep {
+                tokens: vec![next],
+                proposed: 0,
+                accepted: 0,
+                finished: self.finished,
+            })
+        })();
+        self.finish(result)
+    }
+
+    pub fn decode(&mut self) -> OpResult<MtpStep> {
+        if self.poisoned || self.finished || self.pending.is_none() {
+            return Err(OpError::Shape(
+                "MTP decode requires an active healthy session".into(),
+            ));
+        }
+        let result = (|| {
+            let available = (self.limits.max_output_tokens - self.generated) as usize;
+            let capacity = self.limits.max_context - self.len;
+            let k = self
+                .limits
+                .draft_tokens
+                .min(available - 1)
+                .min(capacity - 1);
+            let drafts = self
+                .proposer
+                .draft(self.pending.unwrap(), k, &self.target.scope)?;
+            let mut ids = Vec::with_capacity(k + 1);
+            ids.push(self.pending.unwrap());
+            ids.extend_from_slice(&drafts);
+            let target = self
+                .target
+                .step_with_hidden(&self.request(&ids, vec![drafts]))?;
+            let retained = target.output.materialized_tokens[0] as usize;
+            self.proposer.observe(
+                &ids[..retained],
+                self.len,
+                &target.normalized_hidden,
+                &self.target.scope,
+            )?;
+            let tokens = target.output.tokens[0]
+                .iter()
+                .map(|t| t.token_id)
+                .collect::<Vec<_>>();
+            self.len += retained;
+            self.generated += tokens.len() as u32;
+            self.pending = tokens.last().copied();
+            self.finished = target.output.finished[0] || self.len >= self.limits.max_context;
+            debug_assert_eq!(self.proposer.committed_len() + 1, self.len);
+            Ok(MtpStep {
+                tokens,
+                proposed: k,
+                accepted: target.output.accepted_drafts.as_ref().unwrap()[0] as usize,
+                finished: self.finished,
+            })
+        })();
+        self.finish(result)
+    }
+
+    fn finish(&mut self, result: OpResult<MtpStep>) -> OpResult<MtpStep> {
+        if result.is_err() {
+            self.poisoned = true;
+            self.target.release_sequence(0);
+        }
+        result
+    }
+
+    fn request(&self, ids: &[i32], draft_tokens: Vec<Vec<i32>>) -> StepRequest {
+        StepRequest {
+            seqs: vec![SeqStep {
+                sequence_id: 0,
+                input_ids: ids.to_vec(),
+                positions: (self.len as i32..(self.len + ids.len()) as i32).collect(),
+                kv_write_start: self.len as i32,
+                kv_len_after: (self.len + ids.len()) as i32,
+                block_table: self.blocks.clone(),
+            }],
+            sampling: vec![],
+            stop: StopCriteria {
+                eos_ids: self.limits.eos_ids.clone(),
+                generated_counts: vec![self.generated],
+                max_tokens: vec![self.limits.max_output_tokens],
+                ignore_eos: vec![false],
+            },
+            draft_tokens,
+        }
+    }
+}

--- a/crates/infer-worker/src/application/speculative/verifier.rs
+++ b/crates/infer-worker/src/application/speculative/verifier.rs
@@ -1,0 +1,390 @@
+use crate::domain::dtype::Dtype;
+use crate::domain::exec::StepCtx;
+use crate::domain::ports::backend::LlmBackend;
+use crate::domain::ports::{OpError, OpResult, SampledToken, SamplingParams};
+use crate::domain::speculative::{DraftBatch, Verification};
+use crate::domain::tensor::Tensor;
+
+/// Deterministic prefix verification. Backend argmax resolves ties, exactly as
+/// in ordinary greedy sampling; CUDA transfers only the per-row token IDs.
+pub struct GreedyVerifier;
+
+impl GreedyVerifier {
+    pub fn verify<T: Dtype, D: LlmBackend>(
+        &self,
+        target_logits: &Tensor<T, D>,
+        drafts: &[Vec<i32>],
+        params: &[SamplingParams],
+        ctx: &StepCtx<'_, D>,
+    ) -> OpResult<Vec<Verification>> {
+        let plan = ctx.plan();
+        validate_sampling(params, plan.batch)?;
+        if drafts.len() != plan.batch {
+            return Err(OpError::Shape(format!(
+                "GreedyVerifier: {} draft sequences != batch {}",
+                drafts.len(),
+                plan.batch
+            )));
+        }
+        let batch = DraftBatch::new(drafts, &plan.q_lens, plan.num_tokens)?;
+        let shape = target_logits.shape().as_slice();
+        if shape.len() != 2 || shape[0] != batch.target_rows() {
+            return Err(OpError::Shape(format!(
+                "GreedyVerifier: expected logits [{}, vocab], got {shape:?}",
+                batch.target_rows()
+            )));
+        }
+        if !target_logits.is_contiguous() {
+            return Err(OpError::Shape(
+                "GreedyVerifier: logits must be contiguous".into(),
+            ));
+        }
+        let vocab = shape[1];
+        if vocab == 0 || vocab > i32::MAX as usize {
+            return Err(OpError::Shape(format!(
+                "GreedyVerifier: vocabulary size {vocab} must fit a positive i32"
+            )));
+        }
+        for seq in batch.sequences() {
+            validate_token_ids(seq.drafts, vocab, "draft")?;
+        }
+        let target_ids = D::argmax(ctx, target_logits)?;
+        verify_predictions(&target_ids, batch, vocab)
+    }
+}
+
+/// Preflight validation, usable before running the target or writing caches.
+/// Empty parameters select the ordinary greedy defaults for every sequence.
+pub fn validate_sampling(params: &[SamplingParams], batch: usize) -> OpResult<()> {
+    if !params.is_empty() && params.len() != batch {
+        return Err(OpError::Shape(format!(
+            "GreedyVerifier: {} sampling parameters != batch {batch}",
+            params.len()
+        )));
+    }
+    for param in params {
+        if !param.temperature.is_finite() || param.temperature < 0.0 {
+            return Err(OpError::Shape(
+                "GreedyVerifier: temperature must be finite and non-negative".into(),
+            ));
+        }
+        if !param.top_p.is_finite() || !(0.0..=1.0).contains(&param.top_p) {
+            return Err(OpError::Shape(
+                "GreedyVerifier: top_p must be in [0, 1]".into(),
+            ));
+        }
+        if !param.min_p.is_finite() || !(0.0..=1.0).contains(&param.min_p) {
+            return Err(OpError::Shape(
+                "GreedyVerifier: min_p must be in [0, 1]".into(),
+            ));
+        }
+        if param.repetition_penalty != 1.0 {
+            return Err(OpError::unsupported(
+                "worker",
+                "greedy verification with repetition penalty requires token history",
+            ));
+        }
+        if !param.is_greedy() {
+            return Err(OpError::unsupported(
+                "worker",
+                "stochastic speculative verification requires draft distributions",
+            ));
+        }
+    }
+    Ok(())
+}
+
+fn validate_token_ids(ids: &[i32], vocab: usize, source: &str) -> OpResult<()> {
+    if let Some(&id) = ids.iter().find(|&&id| id < 0 || id as usize >= vocab) {
+        return Err(OpError::Shape(format!(
+            "GreedyVerifier: {source} token {id} outside vocabulary [0, {vocab})"
+        )));
+    }
+    Ok(())
+}
+
+fn verify_predictions(
+    target_ids: &[i32],
+    batch: DraftBatch<'_>,
+    vocab: usize,
+) -> OpResult<Vec<Verification>> {
+    if target_ids.len() != batch.target_rows() {
+        return Err(OpError::Shape(format!(
+            "GreedyVerifier: backend returned {} predictions for {} target rows",
+            target_ids.len(),
+            batch.target_rows()
+        )));
+    }
+    validate_token_ids(target_ids, vocab, "target")?;
+    let mut decisions = Vec::with_capacity(batch.batch_size());
+    for seq in batch.sequences() {
+        let predicted = &target_ids[seq.target_rows];
+        let accepted_drafts = seq
+            .drafts
+            .iter()
+            .zip(predicted)
+            .take_while(|(draft, target)| draft == target)
+            .count();
+        decisions.push(Verification {
+            accepted_drafts,
+            correction_or_bonus: SampledToken {
+                token_id: predicted[accepted_drafts],
+                // Match ordinary greedy sampling, which does not compute a
+                // probability distribution or top-logprob list on this path.
+                logprob: 0.0,
+                top_logprobs: Vec::new(),
+            },
+        });
+    }
+    Ok(decisions)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::domain::exec::HostScope;
+    use crate::domain::plan::{BatchKind, BatchPlan, MaskMode};
+    use crate::infrastructure::cpu::Cpu;
+
+    fn plan(q_lens: &[i32]) -> BatchPlan {
+        BatchPlan {
+            kind: BatchKind::Spec {
+                mask: MaskMode::Causal,
+                mask_handle: None,
+            },
+            num_tokens: q_lens.iter().map(|&q| q as usize).sum(),
+            batch: q_lens.len(),
+            q_lens: q_lens.to_vec(),
+            kv_lens: q_lens.to_vec(),
+            seq_positions: vec![0; q_lens.len()],
+            rope_positions: q_lens.iter().flat_map(|&q| 0..q).collect(),
+            max_blocks_per_seq: 2,
+            block_size: 16,
+            total_q_tiles: 1,
+        }
+    }
+
+    fn logits(predictions: &[i32], vocab: usize) -> Tensor<f32, Cpu> {
+        let mut values = vec![-1.0; predictions.len() * vocab];
+        for (row, &token) in predictions.iter().enumerate() {
+            values[row * vocab + token as usize] = 4.0;
+        }
+        Tensor::from_host_slice(&values, [predictions.len(), vocab], &Cpu).unwrap()
+    }
+
+    fn decisions(predictions: &[i32], drafts: &[Vec<i32>]) -> Vec<(usize, i32)> {
+        let scope = HostScope::new(Cpu);
+        let q_lens = drafts
+            .iter()
+            .map(|draft| draft.len() as i32 + 1)
+            .collect::<Vec<_>>();
+        let plan = plan(&q_lens);
+        let ctx = StepCtx::new(&scope, &plan);
+        GreedyVerifier
+            .verify(&logits(predictions, 8), drafts, &[], &ctx)
+            .unwrap()
+            .into_iter()
+            .map(|decision| {
+                (
+                    decision.accepted_drafts,
+                    decision.correction_or_bonus.token_id,
+                )
+            })
+            .collect()
+    }
+
+    #[test]
+    fn first_rejection_uses_the_first_prediction_and_accepts_no_later_drafts() {
+        assert_eq!(decisions(&[4, 2, 3], &[vec![1, 2]]), vec![(0, 4)]);
+    }
+
+    #[test]
+    fn partial_acceptance_uses_the_rejection_row() {
+        assert_eq!(decisions(&[1, 4, 3, 5], &[vec![1, 2, 3]]), vec![(1, 4)]);
+    }
+
+    #[test]
+    fn full_acceptance_uses_an_independent_bonus_row() {
+        assert_eq!(decisions(&[1, 2, 7], &[vec![1, 2]]), vec![(2, 7)]);
+        assert_eq!(decisions(&[1, 7], &[vec![1]]), vec![(1, 7)]);
+    }
+
+    #[test]
+    fn zero_drafts_still_requires_one_target_prediction() {
+        assert_eq!(decisions(&[6], &[vec![]]), vec![(0, 6)]);
+    }
+
+    #[test]
+    fn ragged_sequences_have_independent_prefixes_and_bonus_rows() {
+        assert_eq!(
+            decisions(&[1, 2, 3, 4, 6, 7], &[vec![1, 2], vec![], vec![5]]),
+            vec![(2, 3), (0, 4), (0, 6)]
+        );
+    }
+
+    #[test]
+    fn tied_logits_follow_the_backend_lowest_id_rule() {
+        let scope = HostScope::new(Cpu);
+        let plan = plan(&[2]);
+        let ctx = StepCtx::new(&scope, &plan);
+        let logits =
+            Tensor::from_host_slice(&[3.0f32, 3.0, 0.0, 0.0, 5.0, 5.0], [2, 3], &Cpu).unwrap();
+        let result = GreedyVerifier
+            .verify(&logits, &[vec![0]], &[], &ctx)
+            .unwrap();
+        assert_eq!(result[0].accepted_drafts, 1);
+        assert_eq!(result[0].correction_or_bonus.token_id, 1);
+    }
+
+    #[test]
+    fn rejects_non_greedy_and_invalid_sampling_parameters() {
+        let default = SamplingParams::default();
+        assert!(validate_sampling(&[default], 2).is_err());
+        for param in [
+            SamplingParams {
+                temperature: 1.0,
+                ..default
+            },
+            SamplingParams {
+                temperature: -1.0,
+                ..default
+            },
+            SamplingParams {
+                temperature: f32::NAN,
+                ..default
+            },
+            SamplingParams {
+                top_p: f32::NAN,
+                ..default
+            },
+            SamplingParams {
+                top_p: -0.1,
+                ..default
+            },
+            SamplingParams {
+                top_p: 1.1,
+                ..default
+            },
+            SamplingParams {
+                min_p: f32::NAN,
+                ..default
+            },
+            SamplingParams {
+                min_p: -0.1,
+                ..default
+            },
+            SamplingParams {
+                min_p: 1.1,
+                ..default
+            },
+            SamplingParams {
+                repetition_penalty: 1.1,
+                ..default
+            },
+        ] {
+            assert!(validate_sampling(&[param], 1).is_err(), "{param:?}");
+        }
+        assert!(validate_sampling(&[], 2).is_ok());
+        assert!(validate_sampling(&[default], 1).is_ok());
+        assert!(
+            validate_sampling(
+                &[SamplingParams {
+                    temperature: 1.0,
+                    top_k: 1,
+                    ..default
+                }],
+                1
+            )
+            .is_ok()
+        );
+        assert!(
+            validate_sampling(
+                &[SamplingParams {
+                    temperature: 1.0,
+                    top_p: 0.0,
+                    ..default
+                }],
+                1
+            )
+            .is_ok()
+        );
+    }
+
+    #[test]
+    fn rejects_bad_logits_and_plan_shapes_before_backend_dispatch() {
+        let scope = HostScope::new(Cpu);
+        let valid_plan = plan(&[2]);
+        let ctx = StepCtx::new(&scope, &valid_plan);
+        for logits in [
+            Tensor::<f32, Cpu>::zeros([2], &Cpu).unwrap(),
+            Tensor::zeros([1, 4], &Cpu).unwrap(),
+            Tensor::zeros([3, 4], &Cpu).unwrap(),
+            Tensor::zeros([2, 0], &Cpu).unwrap(),
+            Tensor::zeros([2, 4], &Cpu)
+                .unwrap()
+                .narrow(1, 0, 2)
+                .unwrap(),
+        ] {
+            assert!(
+                GreedyVerifier
+                    .verify(&logits, &[vec![1]], &[], &ctx)
+                    .is_err()
+            );
+        }
+        assert!(
+            GreedyVerifier
+                .verify(&logits(&[1, 2], 4), &[], &[], &ctx)
+                .is_err()
+        );
+        assert!(
+            GreedyVerifier
+                .verify(&logits(&[1, 2], 4), &[vec![]], &[], &ctx)
+                .is_err()
+        );
+        let mut wrong_batch = valid_plan.clone();
+        wrong_batch.batch = 2;
+        assert!(
+            GreedyVerifier
+                .verify(
+                    &logits(&[1, 2], 4),
+                    &[vec![1]],
+                    &[],
+                    &StepCtx::new(&scope, &wrong_batch)
+                )
+                .is_err()
+        );
+        let mut wrong_rows = valid_plan;
+        wrong_rows.num_tokens = 1;
+        assert!(
+            GreedyVerifier
+                .verify(
+                    &logits(&[1, 2], 4),
+                    &[vec![1]],
+                    &[],
+                    &StepCtx::new(&scope, &wrong_rows)
+                )
+                .is_err()
+        );
+    }
+
+    #[test]
+    fn rejects_out_of_vocabulary_draft_and_backend_ids() {
+        let scope = HostScope::new(Cpu);
+        let plan = plan(&[2]);
+        let ctx = StepCtx::new(&scope, &plan);
+        let logits = logits(&[1, 2], 4);
+        for draft in [-1, 4] {
+            assert!(
+                GreedyVerifier
+                    .verify(&logits, &[vec![draft]], &[], &ctx)
+                    .is_err()
+            );
+        }
+        let drafts = [vec![1]];
+        let batch = DraftBatch::new(&drafts, &[2], 2).unwrap();
+        assert!(verify_predictions(&[1], batch, 4).is_err());
+        assert!(verify_predictions(&[1, 2, 3], batch, 4).is_err());
+        assert!(verify_predictions(&[1, -1], batch, 4).is_err());
+        assert!(verify_predictions(&[1, 4], batch, 4).is_err());
+    }
+}

--- a/crates/infer-worker/src/application/speculative/verifier.rs
+++ b/crates/infer-worker/src/application/speculative/verifier.rs
@@ -9,6 +9,8 @@ use crate::domain::tensor::Tensor;
 /// in ordinary greedy sampling; CUDA transfers only the per-row token IDs.
 pub struct GreedyVerifier;
 
+type ArgmaxScratch<'a, D> = (&'a mut Tensor<i32, D>, &'a Tensor<f32, D>);
+
 impl GreedyVerifier {
     pub fn verify<T: Dtype, D: LlmBackend>(
         &self,
@@ -16,6 +18,30 @@ impl GreedyVerifier {
         drafts: &[Vec<i32>],
         params: &[SamplingParams],
         ctx: &StepCtx<'_, D>,
+    ) -> OpResult<Vec<Verification>> {
+        self.verify_impl(target_logits, drafts, params, ctx, None)
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub fn verify_into<T: Dtype, D: LlmBackend>(
+        &self,
+        target_logits: &Tensor<T, D>,
+        drafts: &[Vec<i32>],
+        params: &[SamplingParams],
+        ctx: &StepCtx<'_, D>,
+        out: &mut Tensor<i32, D>,
+        workspace: &Tensor<f32, D>,
+    ) -> OpResult<Vec<Verification>> {
+        self.verify_impl(target_logits, drafts, params, ctx, Some((out, workspace)))
+    }
+
+    fn verify_impl<T: Dtype, D: LlmBackend>(
+        &self,
+        target_logits: &Tensor<T, D>,
+        drafts: &[Vec<i32>],
+        params: &[SamplingParams],
+        ctx: &StepCtx<'_, D>,
+        scratch: Option<ArgmaxScratch<'_, D>>,
     ) -> OpResult<Vec<Verification>> {
         let plan = ctx.plan();
         validate_sampling(params, plan.batch)?;
@@ -48,7 +74,12 @@ impl GreedyVerifier {
         for seq in batch.sequences() {
             validate_token_ids(seq.drafts, vocab, "draft")?;
         }
-        let target_ids = D::argmax(ctx, target_logits)?;
+        let target_ids = if let Some((out, workspace)) = scratch {
+            D::argmax_into(ctx, target_logits, out, workspace, None)?;
+            out.to_host_vec()?
+        } else {
+            D::argmax(ctx, target_logits)?
+        };
         verify_predictions(&target_ids, batch, vocab)
     }
 }

--- a/crates/infer-worker/src/application/worker_scheduler.rs
+++ b/crates/infer-worker/src/application/worker_scheduler.rs
@@ -21,6 +21,9 @@ use crate::infrastructure::cuda::Cuda;
 use crate::infrastructure::transport::control_pump::ControlPump;
 use crate::infrastructure::transport::data_pump::DataPump;
 
+mod eager_prefill;
+pub(crate) use eager_prefill::handle_eager_prefill;
+
 fn sampling_params(params: &WireSamplingParams) -> SamplingParams {
     SamplingParams {
         temperature: params.temperature,

--- a/crates/infer-worker/src/application/worker_scheduler/eager_prefill.rs
+++ b/crates/infer-worker/src/application/worker_scheduler/eager_prefill.rs
@@ -1,0 +1,83 @@
+//! Explicit eager prefill adapter sharing ordinary planning and commit rules.
+use super::*;
+
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn handle_eager_prefill<M, F>(
+    cmd: &PrefillBatchCmd,
+    runner: &mut Runtime<bf16, Cuda, M>,
+    active: &mut ActiveSeqMap,
+    prefilling: &mut PrefillSeqMap,
+    allocator: &mut GlobalKvAllocator,
+    eos_ids: &[i32],
+    forward: F,
+) -> OpResult<StepOutput>
+where
+    M: DecoderModel<bf16, Cuda>,
+    F: FnOnce(
+        &mut Runtime<bf16, Cuda, M>,
+        &StepRequest,
+    ) -> OpResult<crate::domain::plan::StepOutput>,
+{
+    cmd.validate(runner.cap_num_tokens, runner.cap_batch)
+        .map_err(|e| OpError::Shape(e.to_string()))?;
+    let (mut plans, total) = plan_prefill_segments(cmd, prefilling);
+    if plans.iter().any(|p| p.skipped) {
+        return Err(OpError::Shape("stale eager prefill segment".into()));
+    }
+    let lease = allocator
+        .lease(total)
+        .map_err(|e| OpError::Shape(e.to_string()))?;
+    let mut seqs = Vec::new();
+    let mut sampling = Vec::new();
+    let mut max_tokens = Vec::new();
+    let mut ignore_eos = Vec::new();
+    let mut kinds = Vec::new();
+    build_prefill_steps_into(
+        cmd,
+        &mut plans,
+        lease.as_slice(),
+        &mut seqs,
+        &mut sampling,
+        &mut max_tokens,
+        &mut ignore_eos,
+        &mut kinds,
+    );
+    let mut req = StepRequest {
+        stop: StopCriteria {
+            eos_ids: eos_ids.to_vec(),
+            generated_counts: vec![0; seqs.len()],
+            max_tokens,
+            ignore_eos,
+        },
+        seqs,
+        sampling,
+        draft_tokens: vec![],
+    };
+    let out = match forward(runner, &req) {
+        Ok(out) => out,
+        Err(error) => {
+            lease.release(allocator);
+            return Err(error);
+        }
+    };
+    reclaim_prefill_step_data(&mut req.seqs, &mut plans);
+    let mut output = StepOutput {
+        tokens: vec![],
+        prefill_done: vec![],
+        assigned_indices: assigned_runs(cmd, &plans, false),
+    };
+    commit_prefill_outputs(
+        cmd,
+        &mut plans,
+        active,
+        prefilling,
+        allocator,
+        false,
+        &out.tokens,
+        &out.finished,
+        0,
+        &mut output,
+    );
+    let _ = lease.commit();
+    Ok(output)
+}

--- a/crates/infer-worker/src/bin/checkpoint_tests/qwen3_5_mtp.rs
+++ b/crates/infer-worker/src/bin/checkpoint_tests/qwen3_5_mtp.rs
@@ -1,0 +1,373 @@
+use super::*;
+use infer_worker::application::speculative::prefill::MtpPrefill;
+use infer_worker::components::mtp::MtpInput;
+use infer_worker::domain::cache::{LinearBatch, LinearLayerState, ModelCacheView};
+use infer_worker::domain::component::{Hidden, LayerRange};
+use infer_worker::domain::exec::StepCtx;
+use infer_worker::domain::forward_scratch::ForwardScratch;
+use infer_worker::domain::gdn_scratch::GdnScratch;
+use infer_worker::domain::kv::{KvIndexTensors, KvQuantTier, PagedKvLayer, PagedKvPool};
+use infer_worker::domain::model::DecoderReadout;
+use infer_worker::domain::plan::{BatchKind, BatchPlan};
+use infer_worker::domain::tensor::Tensor;
+fn indices<D: infer_worker::domain::ports::backend::LlmBackend>(
+    start: usize,
+    n: usize,
+    blocks: usize,
+    device: &D,
+) -> (BatchPlan, KvIndexTensors<D>) {
+    let positions: Vec<i32> = (start as i32..(start + n) as i32).collect();
+    let (cu, req, tile) = BatchPlan::plan_ragged_tiles(&[n as i32]);
+    let plan = BatchPlan {
+        kind: if n == 1 {
+            BatchKind::DecodeOnly
+        } else {
+            BatchKind::Ragged
+        },
+        num_tokens: n,
+        batch: 1,
+        q_lens: vec![n as i32],
+        kv_lens: vec![(start + n) as i32],
+        seq_positions: vec![start as i32],
+        rope_positions: positions.clone(),
+        max_blocks_per_seq: blocks,
+        block_size: 1,
+        total_q_tiles: req.len() as i32,
+    };
+    let ints = |v: &[i32]| Tensor::from_host_slice(v, [v.len()], device).unwrap();
+    let idx = KvIndexTensors {
+        block_tables: Tensor::from_host_slice(
+            &(0..blocks as i32).collect::<Vec<_>>(),
+            [1, blocks],
+            device,
+        )
+        .unwrap(),
+        cu_q_lens: ints(&cu),
+        kv_lens: ints(&plan.kv_lens),
+        seq_positions: ints(&[start as i32]),
+        seq_lens_step: ints(&[n as i32]),
+        rope_positions: ints(&positions),
+        block2req: ints(&req),
+        block2tile: ints(&tile),
+        valid_q_tiles: ints(&[req.len() as i32]),
+        valid_suffix_q_tiles: ints(&[req.len() as i32]),
+    };
+    (plan, idx)
+}
+fn pool<
+    T: infer_worker::domain::dtype::Dtype,
+    D: infer_worker::domain::ports::backend::LlmBackend,
+>(
+    layers: usize,
+    blocks: usize,
+    kv_dim: usize,
+    device: &D,
+) -> PagedKvPool<T, D> {
+    PagedKvPool {
+        layers: (0..layers)
+            .map(|_| PagedKvLayer {
+                k: Tensor::zeros([blocks, 1, kv_dim], device).unwrap(),
+                v: Tensor::zeros([blocks, 1, kv_dim], device).unwrap(),
+            })
+            .collect(),
+        num_blocks: blocks,
+        block_size: 1,
+        kv_dim,
+        quant: KvQuantTier::None,
+        seq_kv_len: Default::default(),
+    }
+}
+
+#[test]
+#[ignore = "requires QWEN35_MTP_REFERENCE, QWEN35_MODEL_PATH and an idle CUDA device"]
+fn qwen35_mtp_checkpoint() {
+    let path = std::env::var("QWEN35_MODEL_PATH").unwrap();
+    let reference = std::path::PathBuf::from(std::env::var("QWEN35_MTP_REFERENCE").unwrap());
+    let dump_dir = std::path::PathBuf::from(std::env::var("QWEN35_MTP_DUMP_DIR").unwrap());
+    std::fs::create_dir_all(&dump_dir).unwrap();
+    let raw = std::fs::read(Path::new(&path).join("config.json")).unwrap();
+    let json: serde_json::Value = serde_json::from_slice(&raw).unwrap();
+    let ids: Vec<i32> =
+        serde_json::from_slice(&std::fs::read(reference.join("tokens.json")).unwrap()).unwrap();
+    let n = ids.len();
+    assert!(n >= 12);
+    let cfg = build_load_config(&parse_hf_config(&raw).unwrap(), n + 16).unwrap();
+    let reader = SafetensorsReader::open(&path).unwrap();
+    let loader = WeightLoader::new(&reader);
+    let cuda = Cuda::new(
+        std::env::var("QWEN35_DEVICE")
+            .unwrap_or_else(|_| "0".into())
+            .parse()
+            .unwrap(),
+    )
+    .unwrap();
+    let scope = cuda.scope();
+    let mut model = qwen3_5::build::<bf16, Cuda>(&loader, &cfg, &cuda).unwrap();
+    let dims = model.dims();
+    let mut head = model
+        .load_mtp(
+            &loader,
+            &cfg,
+            &serde_json::from_value(json["text_config"].clone()).unwrap(),
+        )
+        .unwrap();
+    assert_eq!(head.cache_layout().num_full_layers(), 1);
+    assert!(head.cache_layout().linear_dims().is_empty());
+    head.prepare(n, 1).unwrap();
+    model.install_scratch(ForwardScratch::new(&cuda, dims, n, 1).unwrap());
+    model
+        .install_gdn_scratch(
+            GdnScratch::new(&cuda, dims.dim, model.cache_layout().linear_dims()[0], n).unwrap(),
+        )
+        .unwrap();
+    let mut target_kv = pool(
+        model.cache_layout().num_full_layers(),
+        n,
+        dims.kv_dim,
+        &cuda,
+    );
+    let mut states: Vec<_> = model
+        .cache_layout()
+        .linear_dims()
+        .iter()
+        .map(|&d| LinearLayerState::new(d, 1, &cuda).unwrap())
+        .collect();
+    let (plan, index) = indices(0, n, n, &cuda);
+    let batch = LinearBatch::new(&[0], &[n as i32], 1, &cuda).unwrap();
+    let mut cache = ModelCacheView::hybrid(&mut target_kv, &index, &mut states, &batch);
+    let ctx = StepCtx::new(&scope, &plan);
+    let ints = |v: &[i32]| Tensor::from_host_slice(v, [v.len()], &cuda).unwrap();
+    let dump = |name: &str, values: &[bf16]| {
+        let bytes: Vec<u8> = values
+            .iter()
+            .flat_map(|x| x.to_f32().to_le_bytes())
+            .collect();
+        std::fs::write(dump_dir.join(format!("{name}.f32")), bytes).unwrap();
+    };
+    let mut residual = Hidden {
+        stream: Tensor::zeros([n, dims.dim], &cuda).unwrap(),
+        pending: None,
+    };
+    model.embed(&ints(&ids), &mut residual, &ctx).unwrap();
+    model
+        .decode_layers(
+            LayerRange::all(dims.num_layers),
+            &mut residual,
+            &mut cache,
+            &ctx,
+        )
+        .unwrap();
+    let mut target = Tensor::zeros([n, dims.dim], &cuda).unwrap();
+    model
+        .normalize_hidden_into(&residual, &mut target, &ctx)
+        .unwrap();
+    dump("target", &target.to_host_vec().unwrap());
+    let bytes = std::fs::read(reference.join("target.f32")).unwrap();
+    let values: Vec<bf16> = bytes
+        .chunks_exact(4)
+        .map(|b| bf16::from_f32(f32::from_le_bytes(b.try_into().unwrap())))
+        .collect();
+    assert_eq!(values.len(), n * dims.dim);
+    let reference_hidden = Tensor::from_host_slice(&values, [n, dims.dim], &cuda).unwrap();
+    for (name, conditioning, cuts) in [
+        ("isolated", &reference_hidden, vec![n]),
+        ("integrated", &target, vec![n]),
+        ("chunked", &reference_hidden, vec![1, 2, 5, 9, n - 1, n]),
+    ] {
+        let mut kv = pool(1, n, dims.kv_dim, &cuda);
+        let mut alignment = MtpPrefill::default();
+        let (mut outputs, mut logits) = (Vec::new(), Vec::new());
+        let mut start = 0;
+        for end in cuts {
+            let positions: Vec<i32> = (start as i32..end as i32).collect();
+            let chunk = alignment
+                .prepare(
+                    &ids[start..end],
+                    &positions,
+                    &conditioning.narrow(0, start, end - start).unwrap(),
+                )
+                .unwrap();
+            let count = chunk.next_token_ids.len();
+            if count > 0 {
+                let (plan, index) = indices(chunk.positions[0] as usize, count, n, &cuda);
+                assert_eq!(plan.rope_positions, chunk.positions);
+                let ctx = StepCtx::new(&scope, &plan);
+                let mut cache = ModelCacheView::full(&mut kv, &index);
+                let mut hidden = Tensor::zeros([count, dims.dim], &cuda).unwrap();
+                head.forward_hidden_into(
+                    MtpInput {
+                        next_token_ids: &ints(&chunk.next_token_ids),
+                        target_hidden: &chunk.target_hidden,
+                    },
+                    &mut cache,
+                    &mut hidden,
+                    &ctx,
+                )
+                .unwrap();
+                let mut projected = Tensor::zeros([count, dims.vocab_size], &cuda).unwrap();
+                head.project_logits_into(&hidden, &mut projected, &ctx)
+                    .unwrap();
+                outputs.extend(hidden.to_host_vec().unwrap());
+                logits.extend(projected.to_host_vec().unwrap());
+            }
+            chunk.commit();
+            start = end;
+        }
+        assert_eq!(alignment.pending().unwrap().0, n as i32 - 1);
+        dump(&format!("{name}_hidden"), &outputs);
+        dump(&format!("{name}_logits"), &logits);
+    }
+}
+
+#[test]
+#[ignore = "requires QWEN35_MODEL_PATH and an idle CUDA device"]
+fn qwen35_mtp_eager_generation() {
+    use infer_worker::application::runtime::Runtime;
+    use infer_worker::application::sampler_stack::GreedySampler;
+    use infer_worker::application::speculative::{MtpLimits, MtpSession};
+    use infer_worker::domain::plan::{SeqStep, StepRequest, StopCriteria};
+    let path = std::env::var("QWEN35_MODEL_PATH").unwrap();
+    let raw = std::fs::read(Path::new(&path).join("config.json")).unwrap();
+    let json: serde_json::Value = serde_json::from_slice(&raw).unwrap();
+    let max_context = 256;
+    let max_step = 64;
+    let output_tokens = 32;
+    let cfg = build_load_config(&parse_hf_config(&raw).unwrap(), max_context).unwrap();
+    let tokenizer =
+        tokenizers::Tokenizer::from_file(Path::new(&path).join("tokenizer.json")).unwrap();
+    let eos = tokenizer.token_to_id("<|im_end|>").unwrap() as i32;
+    let prompts = [
+        "What is 2 + 2? Answer with just the number.",
+        "用一句话介绍 Rust 编程语言。",
+        "Write a Python function that adds two numbers. Output only code.",
+    ];
+    let ids: Vec<Vec<i32>> = prompts.iter().map(|prompt| {
+        tokenizer.encode(format!("<|im_start|>user\n{prompt}<|im_end|>\n<|im_start|>assistant\n<think>\n\n</think>\n\n"), false)
+            .unwrap().get_ids().iter().map(|&id| id as i32).collect()
+    }).collect();
+    let reader = SafetensorsReader::open(&path).unwrap();
+    let loader = WeightLoader::new(&reader);
+    let cuda = Cuda::new(
+        std::env::var("QWEN35_DEVICE")
+            .unwrap_or_else(|_| "0".into())
+            .parse()
+            .unwrap(),
+    )
+    .unwrap();
+    let baseline = {
+        let model = qwen3_5::build::<bf16, Cuda>(&loader, &cfg, &cuda).unwrap();
+        let blocks = max_context.div_ceil(16);
+        let mut runtime = Runtime::new(
+            model,
+            cuda.scope(),
+            Box::new(GreedySampler),
+            blocks,
+            16,
+            blocks,
+            max_context,
+            max_step,
+            1,
+            vec![],
+        )
+        .unwrap();
+        ids.iter()
+            .map(|prompt| {
+                runtime.release_sequence(0);
+                let mut len = 0;
+                let mut output = Vec::new();
+                let mut run = |tokens: &[i32]| {
+                    let req = StepRequest {
+                        seqs: vec![SeqStep {
+                            sequence_id: 0,
+                            input_ids: tokens.to_vec(),
+                            positions: (len as i32..(len + tokens.len()) as i32).collect(),
+                            kv_write_start: len as i32,
+                            kv_len_after: (len + tokens.len()) as i32,
+                            block_table: (0..blocks as u32).collect(),
+                        }],
+                        sampling: vec![],
+                        stop: StopCriteria {
+                            eos_ids: vec![eos],
+                            generated_counts: vec![0],
+                            max_tokens: vec![output_tokens],
+                            ignore_eos: vec![false],
+                        },
+                        draft_tokens: vec![],
+                    };
+                    let result = runtime.step(&req).unwrap();
+                    len += tokens.len();
+                    result.tokens[0][0].token_id
+                };
+                let mut next = 0;
+                for chunk in prompt.chunks(max_step) {
+                    next = run(chunk);
+                }
+                output.push(next);
+                while output.len() < output_tokens as usize && next != eos {
+                    next = run(&[next]);
+                    output.push(next);
+                }
+                output
+            })
+            .collect::<Vec<_>>()
+    };
+    let mut reports = Vec::new();
+    for k in [0, 1, 3] {
+        let model = qwen3_5::build::<bf16, Cuda>(&loader, &cfg, &cuda).unwrap();
+        let head = model
+            .load_mtp(
+                &loader,
+                &cfg,
+                &serde_json::from_value(json["text_config"].clone()).unwrap(),
+            )
+            .unwrap();
+        let mut session = MtpSession::new(
+            model,
+            head,
+            cuda.scope(),
+            MtpLimits {
+                max_context,
+                max_step_tokens: max_step,
+                max_output_tokens: output_tokens,
+                draft_tokens: k,
+                eos_ids: vec![eos],
+            },
+        )
+        .unwrap();
+        for (i, prompt) in ids.iter().enumerate() {
+            session.reset().unwrap();
+            let mut step = session.prefill(prompt).unwrap();
+            let mut output = step.tokens.clone();
+            let mut proposed = 0;
+            let mut accepted = 0;
+            let mut rounds = 0;
+            while !step.finished {
+                step = session.decode().unwrap();
+                proposed += step.proposed;
+                accepted += step.accepted;
+                rounds += 1;
+                output.extend_from_slice(&step.tokens);
+                assert_eq!(session.cached_tokens(), session.draft_cached_tokens() + 1);
+            }
+            let text = tokenizer
+                .decode(
+                    &output.iter().map(|&id| id as u32).collect::<Vec<_>>(),
+                    true,
+                )
+                .unwrap();
+            eprintln!(
+                "MTP K={k} prompt={i}: {accepted}/{proposed} accepted, {rounds} rounds, output={text:?}"
+            );
+            reports.push(serde_json::json!({ "k": k, "prompt": prompts[i], "tokens": output,
+                "baseline_tokens": baseline[i], "match": output == baseline[i], "accepted": accepted,
+                "proposed": proposed, "rounds": rounds, "text": text }));
+        }
+    }
+    if let Ok(path) = std::env::var("QWEN35_MTP_GENERATION_REPORT") {
+        std::fs::write(path, serde_json::to_vec_pretty(&reports).unwrap()).unwrap();
+    }
+    assert!(
+        reports.iter().all(|r| r["match"] == true),
+        "MTP generation differs from ordinary greedy; see report"
+    );
+}

--- a/crates/infer-worker/src/bin/worker_main.rs
+++ b/crates/infer-worker/src/bin/worker_main.rs
@@ -775,6 +775,10 @@ fn main() -> Result<(), String> {
         tp_devices: &all_devices,
     };
 
+    if cfg.mtp_num_draft_tokens > 0 && model_type != "qwen3_5" {
+        return Err("MTP serving currently requires a Qwen3.5 dense checkpoint".into());
+    }
+
     match model_type.as_str() {
         "llama3" => {
             let model = llama3::build::<bf16, Cuda>(&loader, &load_cfg, &cuda)
@@ -847,15 +851,41 @@ fn main() -> Result<(), String> {
                 "[bootstrap] weights loaded in {:.2}s",
                 load_start.elapsed().as_secs_f32()
             );
-            run_with_model(
-                &control,
-                &data,
-                model,
-                make_bootstrap(),
-                followers,
-                &eos_ids,
-                args.profile_cuda_steps,
-            )?;
+            if cfg.mtp_num_draft_tokens > 0 {
+                let mtp_config = serde_json::from_value(full_config["text_config"].clone())
+                    .map_err(|e| format!("MTP config: {e}"))?;
+                let head = model
+                    .load_mtp(&loader, &load_cfg, &mtp_config)
+                    .map_err(|e| format!("MTP load: {e}"))?;
+                let execution = infer_worker::application::speculative::serving::MtpServing::new(
+                    head,
+                    max_seq_len,
+                    load.max_batch_tokens,
+                    cfg.mtp_num_draft_tokens,
+                    &cuda,
+                )
+                .map_err(|e| format!("MTP serving: {e}"))?;
+                infer_worker::application::serve_loop::run_with_model_and_execution(
+                    &control,
+                    &data,
+                    model,
+                    make_bootstrap(),
+                    followers,
+                    &eos_ids,
+                    args.profile_cuda_steps,
+                    execution,
+                )?;
+            } else {
+                run_with_model(
+                    &control,
+                    &data,
+                    model,
+                    make_bootstrap(),
+                    followers,
+                    &eos_ids,
+                    args.profile_cuda_steps,
+                )?;
+            }
         }
         "qwen3_moe" => {
             let model = qwen3_moe::build::<bf16, Cuda>(&loader, &load_cfg, &cuda)
@@ -1293,7 +1323,7 @@ mod qwen35_checkpoint_tests {
                 stream: Tensor::zeros([n, dims.dim], &cuda).unwrap(),
                 pending: None,
             };
-            model.embed(&ints(&ids), &mut hidden, &ctx).unwrap();
+            model.embed(&ints(ids), &mut hidden, &ctx).unwrap();
             dump(
                 format!("step{step}_embed.f32"),
                 hidden.stream.to_host_vec().unwrap(),
@@ -2230,3 +2260,7 @@ mod qwen35_checkpoint_tests {
 #[cfg(test)]
 #[path = "checkpoint_tests/qwen3_moe.rs"]
 mod qwen3_moe_checkpoint_tests;
+
+#[cfg(test)]
+#[path = "checkpoint_tests/qwen3_5_mtp.rs"]
+mod qwen35_mtp_checkpoint_tests;

--- a/crates/infer-worker/src/components/mod.rs
+++ b/crates/infer-worker/src/components/mod.rs
@@ -12,6 +12,7 @@ pub mod moe_experts;
 pub mod moe_local;
 pub mod moe_permute;
 pub mod moe_router;
+pub mod mtp;
 pub mod norm;
 
 pub use attention::Attention;

--- a/crates/infer-worker/src/components/mtp.rs
+++ b/crates/infer-worker/src/components/mtp.rs
@@ -1,0 +1,165 @@
+//! Hidden-conditioned draft head. Model families supply weights and a decoder.
+//! KV state belongs to the caller; all mutable work buffers are head-local.
+use crate::components::{Linear, RmsNorm};
+use crate::domain::cache::{CacheLayout, ModelCacheView};
+use crate::domain::component::{Hidden, LayerRange};
+use crate::domain::dtype::Dtype;
+use crate::domain::exec::StepCtx;
+use crate::domain::forward_scratch::ForwardScratch;
+use crate::domain::model::{DecoderReadout, ModelDims};
+use crate::domain::ports::backend::LlmBackend;
+use crate::domain::ports::{OpError, OpResult};
+use crate::domain::tensor::Tensor;
+
+/// Each row pairs target final-normalized h_i with token_(i+1).
+/// The execution plan and KV write position must refer to i, not i+1.
+pub struct MtpInput<'a, T: Dtype, D: LlmBackend> {
+    pub next_token_ids: &'a Tensor<i32, D>,
+    pub target_hidden: &'a Tensor<T, D>,
+}
+
+/// The decoder implementation is selected at compile time. This component
+/// depends only on its domain contract, never on a concrete model family.
+pub struct MtpHead<T: Dtype, D: LlmBackend, M: DecoderReadout<T, D>> {
+    embedding_norm: RmsNorm<T, D>,
+    hidden_norm: RmsNorm<T, D>,
+    fc: Linear<T, D>,
+    decoder: M,
+    scratch: Option<MtpScratch<T, D>>,
+}
+
+struct MtpScratch<T: Dtype, D: LlmBackend> {
+    embeddings: Tensor<T, D>,
+    norm_embedding: Tensor<T, D>,
+    norm_hidden: Tensor<T, D>,
+    concatenated: Tensor<T, D>,
+    projected: Tensor<T, D>,
+    capacity: usize,
+    max_batch: usize,
+}
+
+impl<T: Dtype, D: LlmBackend, M: DecoderReadout<T, D>> MtpHead<T, D, M> {
+    pub(crate) fn new(
+        embedding_norm: RmsNorm<T, D>,
+        hidden_norm: RmsNorm<T, D>,
+        fc: Linear<T, D>,
+        decoder: M,
+    ) -> Self {
+        Self {
+            embedding_norm,
+            hidden_norm,
+            fc,
+            decoder,
+            scratch: None,
+        }
+    }
+
+    pub fn dims(&self) -> ModelDims {
+        self.decoder.dims()
+    }
+    pub fn device(&self) -> &D {
+        self.embedding_norm.weight.device()
+    }
+    pub fn cache_layout(&self) -> &CacheLayout {
+        self.decoder.cache_layout()
+    }
+
+    /// Allocate a separate workspace once, before execution or graph capture.
+    pub fn prepare(&mut self, max_tokens: usize, max_batch: usize) -> OpResult<()> {
+        if max_tokens == 0 || max_batch == 0 || max_batch > max_tokens {
+            return Err(OpError::Shape("invalid MTP workspace capacity".into()));
+        }
+        let dims = self.dims();
+        let device = self.embedding_norm.weight.device();
+        let alloc = |cols| Tensor::zeros([max_tokens, cols], device);
+        let scratch = MtpScratch {
+            embeddings: alloc(dims.dim)?,
+            norm_embedding: alloc(dims.dim)?,
+            norm_hidden: alloc(dims.dim)?,
+            concatenated: alloc(2 * dims.dim)?,
+            projected: alloc(dims.dim)?,
+            capacity: max_tokens,
+            max_batch,
+        };
+        // Projection uses caller-owned logits: no full-vocabulary scratch needed.
+        let forward = ForwardScratch::new(
+            device,
+            ModelDims {
+                vocab_size: 0,
+                ..dims
+            },
+            max_tokens,
+            max_batch,
+        )?;
+        self.decoder.install_scratch(forward);
+        self.scratch = Some(scratch);
+        Ok(())
+    }
+
+    pub fn forward_hidden_into(
+        &self,
+        input: MtpInput<'_, T, D>,
+        cache: &mut ModelCacheView<'_, T, D>,
+        output: &mut Tensor<T, D>,
+        ctx: &StepCtx<'_, D>,
+    ) -> OpResult<()> {
+        let n = ctx.plan().num_tokens;
+        let dim = self.dims().dim;
+        let scratch = self
+            .scratch
+            .as_ref()
+            .ok_or_else(|| OpError::Shape("MTP workspace not prepared".into()))?;
+        if n == 0
+            || n > scratch.capacity
+            || ctx.plan().batch > scratch.max_batch
+            || input.next_token_ids.shape().as_slice() != [n]
+            || input.target_hidden.shape().as_slice() != [n, dim]
+            || output.shape().as_slice() != [n, dim]
+            || !input.next_token_ids.is_contiguous()
+            || !input.target_hidden.is_contiguous()
+            || !output.is_contiguous()
+        {
+            return Err(OpError::Shape(
+                "MTP input/output shape or capacity mismatch".into(),
+            ));
+        }
+        cache.validate(
+            self.cache_layout(),
+            LayerRange::all(self.dims().num_layers),
+            ctx.plan(),
+        )?;
+        let mut embedded = Hidden {
+            stream: scratch.embeddings.narrow(0, 0, n)?,
+            pending: None,
+        };
+        self.decoder
+            .embed(input.next_token_ids, &mut embedded, ctx)?;
+        let mut e = scratch.norm_embedding.narrow(0, 0, n)?;
+        let mut h = scratch.norm_hidden.narrow(0, 0, n)?;
+        self.embedding_norm.forward(&embedded.stream, &mut e, ctx)?;
+        self.hidden_norm.forward(input.target_hidden, &mut h, ctx)?;
+        let mut cat = scratch.concatenated.narrow(0, 0, n)?;
+        D::concat_cols(ctx.scope(), &e, &h, &mut cat)?;
+        let mut hidden = Hidden {
+            stream: scratch.projected.narrow(0, 0, n)?,
+            pending: None,
+        };
+        self.fc.forward(&cat, &mut hidden.stream, ctx)?;
+        self.decoder.decode_layers(
+            LayerRange::all(self.dims().num_layers),
+            &mut hidden,
+            cache,
+            ctx,
+        )?;
+        self.decoder.normalize_hidden_into(&hidden, output, ctx)
+    }
+
+    pub fn project_logits_into(
+        &self,
+        normalized: &Tensor<T, D>,
+        output: &mut Tensor<T, D>,
+        ctx: &StepCtx<'_, D>,
+    ) -> OpResult<()> {
+        self.decoder.project_logits_into(normalized, output, ctx)
+    }
+}

--- a/crates/infer-worker/src/domain/cache.rs
+++ b/crates/infer-worker/src/domain/cache.rs
@@ -11,6 +11,9 @@ use super::ports::backend::LlmBackend;
 use super::ports::{OpError, OpResult};
 use super::tensor::Tensor;
 
+mod snapshot;
+pub use snapshot::LinearSnapshot;
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct LinearDims {
     pub num_key_heads: usize,
@@ -232,10 +235,18 @@ impl<D: LlmBackend> LinearBatch<D> {
     }
 
     pub fn validate_plan(&self, plan: &BatchPlan) -> OpResult<()> {
-        if matches!(plan.kind, BatchKind::Spec { .. }) {
+        if matches!(plan.kind, BatchKind::Spec { .. })
+            && !matches!(
+                plan.kind,
+                BatchKind::Spec {
+                    mask: super::plan::MaskMode::Causal,
+                    mask_handle: None,
+                }
+            )
+        {
             return Err(OpError::unsupported(
                 "linear attention",
-                "speculative execution",
+                "non-causal speculative execution",
             ));
         }
         if plan.batch != self.q_lens.len()

--- a/crates/infer-worker/src/domain/cache/snapshot.rs
+++ b/crates/infer-worker/src/domain/cache/snapshot.rs
@@ -1,0 +1,114 @@
+//! Owned recurrent checkpoints. KV suffix retention is a separate concern.
+use super::*;
+
+/// Copies only the participating request slots, including convolution history
+/// and FP32 delta-rule state. Source and checkpoint never share storage.
+/// The caller must order execution around these default-device-stream copies.
+pub struct LinearSnapshot<T: Dtype, D: LlmBackend> {
+    slots: Vec<usize>,
+    layers: Vec<LinearLayerState<T, D>>,
+}
+
+impl<T: Dtype, D: LlmBackend> LinearSnapshot<T, D> {
+    pub fn capture(layers: &[LinearLayerState<T, D>], slots: &[usize]) -> OpResult<Self> {
+        let unique: HashSet<_> = slots.iter().copied().collect();
+        if slots.is_empty()
+            || unique.len() != slots.len()
+            || layers
+                .iter()
+                .any(|l| slots.iter().any(|&s| s >= l.conv.shape()[0]))
+        {
+            return Err(OpError::Shape("invalid recurrent snapshot slots".into()));
+        }
+        let mut saved = Vec::with_capacity(layers.len());
+        for layer in layers {
+            let copy = LinearLayerState::new(layer.dims, slots.len(), layer.conv.device())?;
+            for (row, &slot) in slots.iter().enumerate() {
+                copy.conv
+                    .narrow(0, row, 1)?
+                    .copy_from(&layer.conv.narrow(0, slot, 1)?)?;
+                copy.ssm
+                    .narrow(0, row, 1)?
+                    .copy_from(&layer.ssm.narrow(0, slot, 1)?)?;
+            }
+            saved.push(copy);
+        }
+        Ok(Self {
+            slots: slots.to_vec(),
+            layers: saved,
+        })
+    }
+
+    pub fn restore(&self, layers: &mut [LinearLayerState<T, D>]) -> OpResult<()> {
+        // Validate every destination before changing any layer.
+        if layers.len() != self.layers.len()
+            || layers.iter().zip(&self.layers).any(|(dst, src)| {
+                dst.dims != src.dims
+                    || self.slots.iter().any(|&s| s >= dst.conv.shape()[0])
+                    || infer_core::device::Device::device_id(dst.conv.device())
+                        != infer_core::device::Device::device_id(src.conv.device())
+            })
+        {
+            return Err(OpError::Shape("recurrent snapshot layout mismatch".into()));
+        }
+        for (dst, src) in layers.iter_mut().zip(&self.layers) {
+            for (row, &slot) in self.slots.iter().enumerate() {
+                dst.conv
+                    .narrow(0, slot, 1)?
+                    .copy_from(&src.conv.narrow(0, row, 1)?)?;
+                dst.ssm
+                    .narrow(0, slot, 1)?
+                    .copy_from(&src.ssm.narrow(0, row, 1)?)?;
+            }
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::infrastructure::cpu::Cpu;
+
+    #[test]
+    fn snapshot_is_owned_and_restores_only_selected_slots() {
+        let dims = LinearDims {
+            num_key_heads: 1,
+            num_value_heads: 1,
+            key_head_dim: 2,
+            value_head_dim: 2,
+            conv_kernel_dim: 4,
+        };
+        let mut layers = vec![LinearLayerState::<f32, _>::new(dims, 3, &Cpu).unwrap()];
+        let fill = |state: &LinearLayerState<f32, Cpu>, value| {
+            for tensor in [&state.conv, &state.ssm] {
+                tensor
+                    .clone()
+                    .upload_from_host(&vec![value; tensor.numel()])
+                    .unwrap();
+            }
+        };
+        fill(&layers[0], 2.0);
+        let snapshot = LinearSnapshot::capture(&layers, &[2, 0]).unwrap();
+        fill(&layers[0], 7.0);
+        snapshot.restore(&mut layers).unwrap();
+        for t in [&layers[0].conv, &layers[0].ssm] {
+            for (slot, expected) in [(0, 2.0), (1, 7.0), (2, 2.0)] {
+                assert!(
+                    t.narrow(0, slot, 1)
+                        .unwrap()
+                        .to_host_vec()
+                        .unwrap()
+                        .iter()
+                        .all(|&x| x == expected)
+                );
+            }
+        }
+        assert!(LinearSnapshot::capture(&layers, &[0, 0]).is_err());
+        assert!(LinearSnapshot::capture(&layers, &[3]).is_err());
+        // Repeated restore does not consume or alias the checkpoint.
+        fill(&layers[0], 9.0);
+        snapshot.restore(&mut layers).unwrap();
+        assert_eq!(layers[0].ssm.to_host_vec().unwrap()[0], 2.0);
+    }
+}

--- a/crates/infer-worker/src/domain/cache/snapshot.rs
+++ b/crates/infer-worker/src/domain/cache/snapshot.rs
@@ -3,13 +3,105 @@ use super::*;
 
 /// Copies only the participating request slots, including convolution history
 /// and FP32 delta-rule state. Source and checkpoint never share storage.
-/// The caller must order execution around these default-device-stream copies.
+/// Scoped copies run in stream order; legacy capture/restore are synchronous.
 pub struct LinearSnapshot<T: Dtype, D: LlmBackend> {
     slots: Vec<usize>,
     layers: Vec<LinearLayerState<T, D>>,
 }
 
 impl<T: Dtype, D: LlmBackend> LinearSnapshot<T, D> {
+    /// Reserve backup storage at startup. Only participating slots are copied.
+    pub fn reserve(layers: &[LinearLayerState<T, D>], capacity: usize) -> OpResult<Self> {
+        Ok(Self {
+            slots: Vec::with_capacity(capacity),
+            layers: layers
+                .iter()
+                .map(|l| LinearLayerState::new(l.dims, capacity, l.conv.device()))
+                .collect::<OpResult<_>>()?,
+        })
+    }
+
+    pub fn capture_on(
+        &mut self,
+        layers: &[LinearLayerState<T, D>],
+        slots: &[usize],
+        scope: &D::Scope,
+    ) -> OpResult<()> {
+        if slots.is_empty()
+            || layers.len() != self.layers.len()
+            || slots
+                .iter()
+                .enumerate()
+                .any(|(i, s)| slots[..i].contains(s))
+            || layers.iter().zip(&self.layers).any(|(src, dst)| {
+                src.dims != dst.dims
+                    || infer_core::device::Device::device_id(src.conv.device())
+                        != infer_core::device::Device::device_id(dst.conv.device())
+                    || infer_core::device::Device::device_id(src.conv.device())
+                        != infer_core::device::Device::device_id(
+                            infer_core::exec::ExecScope::device(scope),
+                        )
+                    || slots.len() > dst.conv.shape()[0]
+                    || slots.iter().any(|&s| s >= src.conv.shape()[0])
+            })
+        {
+            return Err(OpError::Shape("invalid recurrent snapshot geometry".into()));
+        }
+        self.slots.clear();
+        self.slots.extend_from_slice(slots);
+        for (src, dst) in layers.iter().zip(&self.layers) {
+            for (row, &slot) in slots.iter().enumerate() {
+                D::copy_tensor(
+                    scope,
+                    &src.conv.narrow(0, slot, 1)?,
+                    &mut dst.conv.narrow(0, row, 1)?,
+                )?;
+                D::copy_tensor(
+                    scope,
+                    &src.ssm.narrow(0, slot, 1)?,
+                    &mut dst.ssm.narrow(0, row, 1)?,
+                )?;
+            }
+        }
+        Ok(())
+    }
+
+    pub fn restore_on(
+        &self,
+        layers: &mut [LinearLayerState<T, D>],
+        scope: &D::Scope,
+    ) -> OpResult<()> {
+        if layers.len() != self.layers.len()
+            || layers.iter().zip(&self.layers).any(|(dst, src)| {
+                dst.dims != src.dims
+                    || infer_core::device::Device::device_id(src.conv.device())
+                        != infer_core::device::Device::device_id(dst.conv.device())
+                    || infer_core::device::Device::device_id(src.conv.device())
+                        != infer_core::device::Device::device_id(
+                            infer_core::exec::ExecScope::device(scope),
+                        )
+                    || self.slots.iter().any(|&s| s >= dst.conv.shape()[0])
+            })
+        {
+            return Err(OpError::Shape("recurrent snapshot layout mismatch".into()));
+        }
+        for (dst, src) in layers.iter_mut().zip(&self.layers) {
+            for (row, &slot) in self.slots.iter().enumerate() {
+                D::copy_tensor(
+                    scope,
+                    &src.conv.narrow(0, row, 1)?,
+                    &mut dst.conv.narrow(0, slot, 1)?,
+                )?;
+                D::copy_tensor(
+                    scope,
+                    &src.ssm.narrow(0, row, 1)?,
+                    &mut dst.ssm.narrow(0, slot, 1)?,
+                )?;
+            }
+        }
+        Ok(())
+    }
+
     pub fn capture(layers: &[LinearLayerState<T, D>], slots: &[usize]) -> OpResult<Self> {
         let unique: HashSet<_> = slots.iter().copied().collect();
         if slots.is_empty()
@@ -110,5 +202,53 @@ mod tests {
         fill(&layers[0], 9.0);
         snapshot.restore(&mut layers).unwrap();
         assert_eq!(layers[0].ssm.to_host_vec().unwrap()[0], 2.0);
+    }
+    #[test]
+    fn reserved_snapshot_reuses_storage_with_reordered_and_smaller_batches() {
+        let dims = LinearDims {
+            num_key_heads: 1,
+            num_value_heads: 1,
+            key_head_dim: 2,
+            value_head_dim: 2,
+            conv_kernel_dim: 4,
+        };
+        let mut layers = vec![LinearLayerState::<f32, _>::new(dims, 3, &Cpu).unwrap()];
+        let scope = infer_core::exec::HostScope::new(Cpu);
+        let mut saved = LinearSnapshot::reserve(&layers, 3).unwrap();
+        let address = saved.layers[0].ssm.data_ptr();
+        for slots in [&[2, 0][..], &[1][..], &[0, 1, 2][..]] {
+            for t in [&layers[0].conv, &layers[0].ssm] {
+                for slot in 0..3 {
+                    let mut row = t.narrow(0, slot, 1).unwrap();
+                    row.upload_from_host(&vec![slot as f32 + 1.; row.numel()])
+                        .unwrap();
+                }
+            }
+            saved.capture_on(&layers, slots, &scope).unwrap();
+            for t in [&layers[0].conv, &layers[0].ssm] {
+                t.clone().upload_from_host(&vec![9.; t.numel()]).unwrap();
+            }
+            saved.restore_on(&mut layers, &scope).unwrap();
+            for t in [&layers[0].conv, &layers[0].ssm] {
+                for slot in 0..3 {
+                    let want = if slots.contains(&slot) {
+                        slot as f32 + 1.
+                    } else {
+                        9.
+                    };
+                    assert!(
+                        t.narrow(0, slot, 1)
+                            .unwrap()
+                            .to_host_vec()
+                            .unwrap()
+                            .iter()
+                            .all(|&x| x == want)
+                    );
+                }
+            }
+            assert_eq!(saved.layers[0].ssm.data_ptr(), address);
+        }
+        assert!(saved.capture_on(&layers, &[0, 0], &scope).is_err());
+        assert!(saved.capture_on(&layers, &[3], &scope).is_err());
     }
 }

--- a/crates/infer-worker/src/domain/mod.rs
+++ b/crates/infer-worker/src/domain/mod.rs
@@ -15,6 +15,7 @@ pub use infer_core::kv;
 mod kv_tests;
 pub mod model;
 pub mod plan;
+pub mod speculative;
 pub mod tensor_parallel;
 pub use infer_core::ports;
 pub use infer_core::storage;

--- a/crates/infer-worker/src/domain/mod.rs
+++ b/crates/infer-worker/src/domain/mod.rs
@@ -38,3 +38,5 @@ pub use storage::Storage;
 pub use tensor::Tensor;
 pub use tensor_parallel::TensorParallelPlacement;
 pub use types::{DataType, Dims, Dtype, MAX_RANK, Shape, Strides};
+
+pub(crate) mod mtp_scratch;

--- a/crates/infer-worker/src/domain/model.rs
+++ b/crates/infer-worker/src/domain/model.rs
@@ -133,3 +133,23 @@ pub trait DecoderModel<T: V2Dtype, D: LlmBackend> {
         self.finalize(hidden, rows, ctx)
     }
 }
+
+/// Optional target-model readout used by hidden-conditioned draft heads.
+/// Outputs belong to the caller and must not alias model forward scratch.
+/// Implementations use static dispatch; ordinary decoders need not expose it.
+pub trait DecoderReadout<T: V2Dtype, D: LlmBackend>: DecoderModel<T, D> {
+    /// Apply the final model norm to a fully materialized residual stream.
+    fn normalize_hidden_into(
+        &self,
+        hidden: &Hidden<T, D>,
+        output: &mut Tensor<T, D>,
+        ctx: &crate::domain::exec::StepCtx<'_, D>,
+    ) -> OpResult<()>;
+    /// Project already normalized hidden states through the shared LM head.
+    fn project_logits_into(
+        &self,
+        normalized: &Tensor<T, D>,
+        output: &mut Tensor<T, D>,
+        ctx: &crate::domain::exec::StepCtx<'_, D>,
+    ) -> OpResult<()>;
+}

--- a/crates/infer-worker/src/domain/mtp_scratch.rs
+++ b/crates/infer-worker/src/domain/mtp_scratch.rs
@@ -106,7 +106,10 @@ impl<T: Dtype, D: LlmBackend> MtpWorkspace<T, D> {
             .upload_from_host(&self.control_host[..=self.pending_offset])
     }
     pub fn prepare_observe(&mut self, ids: &[i32], start: usize) -> OpResult<()> {
-        let n = ids.len();
+        self.prepare_observe_index(ids.len(), start)?;
+        self.input(ids.len())?.upload_from_host(ids)
+    }
+    pub fn prepare_observe_index(&mut self, n: usize, start: usize) -> OpResult<()> {
         self.set_plan(start, n);
         let tiles = self.plan.total_q_tiles as usize;
         self.control_host[..5].copy_from_slice(&[
@@ -127,8 +130,7 @@ impl<T: Dtype, D: LlmBackend> MtpWorkspace<T, D> {
         let used = 7 + n + 2 * tiles;
         self.control
             .narrow(0, 0, used)?
-            .upload_from_host(&self.control_host[..used])?;
-        self.input(n)?.upload_from_host(ids)
+            .upload_from_host(&self.control_host[..used])
     }
     pub fn index(&self, slot: usize, n: usize) -> OpResult<KvIndexTensors<D>> {
         let tiles = n.div_ceil(RAGGED_Q_TILE as usize);
@@ -223,5 +225,29 @@ mod tests {
             ws.hidden(0, 1).unwrap().data_ptr(),
             ws.hidden(1, 1).unwrap().data_ptr()
         );
+    }
+    #[test]
+    fn catchup_index_updates_preserve_device_token_tape() {
+        let mut ws = MtpWorkspace::<f32, _>::new(
+            ModelDims {
+                dim: 4,
+                vocab_size: 8,
+                ..Default::default()
+            },
+            64,
+            8,
+            &Cpu,
+        )
+        .unwrap();
+        let mut tape = ws.input(4).unwrap();
+        tape.upload_from_host(&[3, 4, 5, 6]).unwrap();
+        for n in [1, 4, 2] {
+            ws.prepare_observe_index(n, 7).unwrap();
+            assert_eq!(tape.to_host_vec().unwrap(), [3, 4, 5, 6]);
+            assert_eq!(
+                ws.index(0, n).unwrap().kv_lens.to_host_vec().unwrap(),
+                [(7 + n) as i32]
+            );
+        }
     }
 }

--- a/crates/infer-worker/src/domain/mtp_scratch.rs
+++ b/crates/infer-worker/src/domain/mtp_scratch.rs
@@ -1,0 +1,227 @@
+//! Startup-owned MTP control/readout buffers, complementing ForwardScratch.
+//! All views have stable storage. Host metadata is packed into one upload per
+//! round, and draft token IDs stay on device between head invocations.
+use super::dtype::Dtype;
+use super::kv::KvIndexTensors;
+use super::model::ModelDims;
+use super::plan::{BatchKind, BatchPlan, RAGGED_Q_TILE};
+use super::ports::OpResult;
+use super::ports::backend::LlmBackend;
+use super::tensor::Tensor;
+
+pub(crate) struct MtpWorkspace<T: Dtype, D: LlmBackend> {
+    control: Tensor<i32, D>,
+    control_host: Vec<i32>,
+    blocks: Tensor<i32, D>,
+    ids: Tensor<i32, D>,
+    pending_offset: usize,
+    hidden: [Tensor<T, D>; 2],
+    positions_host: Vec<i32>,
+    pub logits: Tensor<T, D>,
+    pub argmax_ws: Tensor<f32, D>,
+    pub plan: BatchPlan,
+}
+
+impl<T: Dtype, D: LlmBackend> MtpWorkspace<T, D> {
+    pub fn new(dims: ModelDims, context: usize, capacity: usize, device: &D) -> OpResult<Self> {
+        let blocks = context.div_ceil(16);
+        let tiles = capacity.div_ceil(RAGGED_Q_TILE as usize);
+        let control_size = (capacity * 10 + 1).max(7 + capacity + tiles * 2);
+        Ok(Self {
+            control: Tensor::zeros([control_size], device)?,
+            control_host: vec![0; control_size],
+            blocks: Tensor::from_host_slice(
+                &(0..blocks as i32).collect::<Vec<_>>(),
+                [1, blocks],
+                device,
+            )?,
+            ids: Tensor::zeros([capacity + 1], device)?,
+            pending_offset: 0,
+            hidden: [
+                Tensor::zeros([capacity, dims.dim], device)?,
+                Tensor::zeros([capacity, dims.dim], device)?,
+            ],
+            positions_host: vec![0; capacity],
+            logits: Tensor::zeros([1, dims.vocab_size], device)?,
+            argmax_ws: Tensor::zeros([512], device)?,
+            plan: BatchPlan {
+                kind: BatchKind::DecodeOnly,
+                num_tokens: 1,
+                batch: 1,
+                q_lens: vec![1],
+                kv_lens: vec![1],
+                seq_positions: vec![0],
+                rope_positions: Vec::with_capacity(capacity),
+                max_blocks_per_seq: blocks,
+                block_size: 16,
+                total_q_tiles: 1,
+            },
+        })
+    }
+    pub fn positions(&mut self, start: usize, n: usize) -> &[i32] {
+        for (i, p) in self.positions_host[..n].iter_mut().enumerate() {
+            *p = (start + i) as i32;
+        }
+        &self.positions_host[..n]
+    }
+    fn set_plan(&mut self, start: usize, n: usize) {
+        self.plan.kind = if n == 1 {
+            BatchKind::DecodeOnly
+        } else {
+            BatchKind::Ragged
+        };
+        self.plan.num_tokens = n;
+        self.plan.q_lens[0] = n as i32;
+        self.plan.kv_lens[0] = (start + n) as i32;
+        self.plan.seq_positions[0] = start as i32;
+        self.plan.rope_positions.clear();
+        self.plan
+            .rope_positions
+            .extend(start as i32..(start + n) as i32);
+        self.plan.total_q_tiles = n.div_ceil(RAGGED_Q_TILE as usize) as i32;
+    }
+    pub fn set_decode_position(&mut self, start: usize) {
+        self.set_plan(start, 1);
+    }
+    pub fn prepare_draft(&mut self, pending: i32, start: usize, count: usize) -> OpResult<()> {
+        for i in 0..count {
+            let p = (start + i) as i32;
+            self.control_host[i * 10..(i + 1) * 10].copy_from_slice(&[
+                0,
+                1,
+                p + 1,
+                p,
+                1,
+                p,
+                0,
+                0,
+                1,
+                1,
+            ]);
+        }
+        self.pending_offset = count * 10;
+        self.control_host[self.pending_offset] = pending;
+        self.control
+            .narrow(0, 0, self.pending_offset + 1)?
+            .upload_from_host(&self.control_host[..=self.pending_offset])
+    }
+    pub fn prepare_observe(&mut self, ids: &[i32], start: usize) -> OpResult<()> {
+        let n = ids.len();
+        self.set_plan(start, n);
+        let tiles = self.plan.total_q_tiles as usize;
+        self.control_host[..5].copy_from_slice(&[
+            0,
+            n as i32,
+            (start + n) as i32,
+            start as i32,
+            n as i32,
+        ]);
+        for i in 0..n {
+            self.control_host[5 + i] = (start + i) as i32;
+        }
+        self.control_host[5 + n..5 + n + tiles].fill(0);
+        for i in 0..tiles {
+            self.control_host[5 + n + tiles + i] = i as i32;
+        }
+        self.control_host[5 + n + 2 * tiles..7 + n + 2 * tiles].fill(tiles as i32);
+        let used = 7 + n + 2 * tiles;
+        self.control
+            .narrow(0, 0, used)?
+            .upload_from_host(&self.control_host[..used])?;
+        self.input(n)?.upload_from_host(ids)
+    }
+    pub fn index(&self, slot: usize, n: usize) -> OpResult<KvIndexTensors<D>> {
+        let tiles = n.div_ceil(RAGGED_Q_TILE as usize);
+        let base = slot * 10;
+        let v = |offset, len| self.control.narrow(0, base + offset, len);
+        Ok(KvIndexTensors {
+            block_tables: self.blocks.clone(),
+            cu_q_lens: v(0, 2)?,
+            kv_lens: v(2, 1)?,
+            seq_positions: v(3, 1)?,
+            seq_lens_step: v(4, 1)?,
+            rope_positions: v(5, n)?,
+            block2req: v(5 + n, tiles)?,
+            block2tile: v(5 + n + tiles, tiles)?,
+            valid_q_tiles: v(5 + n + tiles * 2, 1)?,
+            valid_suffix_q_tiles: v(6 + n + tiles * 2, 1)?,
+        })
+    }
+    pub fn input(&self, n: usize) -> OpResult<Tensor<i32, D>> {
+        self.ids.narrow(0, 0, n)
+    }
+    pub fn token(&self, i: usize) -> OpResult<Tensor<i32, D>> {
+        if i == 0 {
+            self.control.narrow(0, self.pending_offset, 1)
+        } else {
+            self.ids.narrow(0, i, 1)
+        }
+    }
+    pub fn drafts(&self, n: usize) -> OpResult<Tensor<i32, D>> {
+        self.ids.narrow(0, 1, n)
+    }
+    pub fn hidden(&self, slot: usize, n: usize) -> OpResult<Tensor<T, D>> {
+        self.hidden[slot].narrow(0, 0, n)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::infrastructure::cpu::Cpu;
+
+    #[test]
+    fn packed_indices_cross_tile_boundaries_and_reuse_storage() {
+        let tile = RAGGED_Q_TILE as usize;
+        let mut ws = MtpWorkspace::<f32, _>::new(
+            ModelDims {
+                dim: 4,
+                vocab_size: 8,
+                ..Default::default()
+            },
+            256,
+            tile * 2 + 1,
+            &Cpu,
+        )
+        .unwrap();
+        let control = ws.control.data_ptr();
+        let blocks = ws.blocks.data_ptr();
+        let hidden = ws.hidden(0, 1).unwrap().data_ptr();
+        for n in [1, tile, tile + 1, tile * 2 + 1, 2, 1] {
+            ws.prepare_observe(&vec![3; n], 7).unwrap();
+            let ix = ws.index(0, n).unwrap();
+            assert_eq!(ix.cu_q_lens.to_host_vec().unwrap(), [0, n as i32]);
+            assert_eq!(ix.kv_lens.to_host_vec().unwrap(), [(7 + n) as i32]);
+            assert_eq!(
+                ix.rope_positions.to_host_vec().unwrap(),
+                (7..(7 + n) as i32).collect::<Vec<_>>()
+            );
+            let tiles = n.div_ceil(tile);
+            assert_eq!(
+                ix.block2tile.to_host_vec().unwrap(),
+                (0..tiles as i32).collect::<Vec<_>>()
+            );
+            assert_eq!(ix.valid_q_tiles.to_host_vec().unwrap(), [tiles as i32]);
+            assert_eq!(
+                ix.valid_suffix_q_tiles.to_host_vec().unwrap(),
+                [tiles as i32]
+            );
+            assert_eq!(ix.block2req.to_host_vec().unwrap(), vec![0; tiles]);
+            assert_eq!(ws.control.data_ptr(), control);
+            assert_eq!(ws.blocks.data_ptr(), blocks);
+            assert_eq!(ws.hidden(0, 1).unwrap().data_ptr(), hidden);
+        }
+        ws.prepare_draft(5, 29, 3).unwrap();
+        for i in 0..3 {
+            let ix = ws.index(i, 1).unwrap();
+            assert_eq!(ix.kv_lens.to_host_vec().unwrap(), [30 + i as i32]);
+            assert_eq!(ix.rope_positions.to_host_vec().unwrap(), [29 + i as i32]);
+            assert_eq!(ix.valid_q_tiles.to_host_vec().unwrap(), [1]);
+        }
+        assert_eq!(ws.token(0).unwrap().to_host_vec().unwrap(), [5]);
+        assert_ne!(
+            ws.hidden(0, 1).unwrap().data_ptr(),
+            ws.hidden(1, 1).unwrap().data_ptr()
+        );
+    }
+}

--- a/crates/infer-worker/src/domain/plan.rs
+++ b/crates/infer-worker/src/domain/plan.rs
@@ -18,13 +18,25 @@ pub struct StepRequest {
     pub seqs: Vec<SeqStep>,
     pub sampling: Vec<crate::domain::ports::sampler::SamplingParams>,
     pub stop: StopCriteria,
+    /// Empty for ordinary execution. Otherwise one draft row per sequence,
+    /// with `seq.input_ids == [pending_token] + draft_tokens[row]`.
+    /// A row with K drafts requires K+1 target prediction rows, including the
+    /// independent correction/bonus prediction. K=0 is a valid verify row.
     pub draft_tokens: Vec<Vec<i32>>,
 }
 
 #[derive(Debug, Clone)]
 pub struct StepOutput {
     pub tokens: Vec<Vec<SampledToken>>,
-    pub accepted: Vec<u32>,
+    /// Leading input tokens eligible for retention by the caller. Ordinary
+    /// steps retain every input; verification retains the pending token plus
+    /// accepted drafts, shortened if output stops early. The last emitted
+    /// token remains pending rather than becoming part of this input prefix.
+    /// The caller owns KV leases and must return the unretained suffix.
+    pub materialized_tokens: Vec<u32>,
+    /// Consecutive matching drafts before EOS/output-budget truncation.
+    /// `None` for ordinary execution; these counts are NOT KV increments.
+    pub accepted_drafts: Option<Vec<u32>>,
     pub finished: Vec<bool>,
     pub hidden_tap: Option<HiddenTap>,
 }

--- a/crates/infer-worker/src/domain/plan.rs
+++ b/crates/infer-worker/src/domain/plan.rs
@@ -53,3 +53,92 @@ pub struct StopCriteria {
 pub struct HiddenTap {
     pub at_layer: usize,
 }
+
+impl StepRequest {
+    /// CPU staging paired with the device workspace. Reuse nested vectors too.
+    pub(crate) fn workspace(batch: usize, tokens: usize, blocks: usize) -> Self {
+        Self {
+            seqs: (0..batch)
+                .map(|_| SeqStep {
+                    sequence_id: 0,
+                    input_ids: Vec::with_capacity(tokens),
+                    positions: Vec::with_capacity(tokens),
+                    kv_write_start: 0,
+                    kv_len_after: 0,
+                    block_table: Vec::with_capacity(blocks),
+                })
+                .collect(),
+            sampling: Vec::with_capacity(batch),
+            stop: StopCriteria {
+                eos_ids: Vec::with_capacity(16),
+                generated_counts: Vec::with_capacity(batch),
+                max_tokens: Vec::with_capacity(batch),
+                ignore_eos: Vec::with_capacity(batch),
+            },
+            draft_tokens: Vec::new(),
+        }
+    }
+
+    pub(crate) fn retain_from(&mut self, req: &Self, lengths: &[u32]) {
+        self.seqs.resize_with(req.seqs.len(), || SeqStep {
+            sequence_id: 0,
+            input_ids: Vec::new(),
+            positions: Vec::new(),
+            kv_write_start: 0,
+            kv_len_after: 0,
+            block_table: Vec::new(),
+        });
+        for ((dst, src), &n) in self.seqs.iter_mut().zip(&req.seqs).zip(lengths) {
+            dst.sequence_id = src.sequence_id;
+            dst.input_ids.clear();
+            dst.input_ids
+                .extend_from_slice(&src.input_ids[..n as usize]);
+            dst.positions.clear();
+            dst.positions
+                .extend_from_slice(&src.positions[..n as usize]);
+            dst.kv_write_start = src.kv_write_start;
+            dst.kv_len_after = src.kv_write_start + n as i32;
+            dst.block_table.clone_from(&src.block_table);
+        }
+        self.sampling.clone_from(&req.sampling);
+        self.stop.eos_ids.clone_from(&req.stop.eos_ids);
+        self.stop
+            .generated_counts
+            .clone_from(&req.stop.generated_counts);
+        self.stop.max_tokens.clone_from(&req.stop.max_tokens);
+        self.stop.ignore_eos.clone_from(&req.stop.ignore_eos);
+        self.draft_tokens.clear();
+    }
+}
+
+#[cfg(test)]
+mod request_workspace_tests {
+    use super::*;
+
+    #[test]
+    fn retaining_prefixes_reuses_nested_storage_without_mutating_request() {
+        let mut request = StepRequest::workspace(1, 4, 16);
+        request.seqs[0].input_ids.extend([10, 11, 12, 13]);
+        request.seqs[0].positions.extend([7, 8, 9, 10]);
+        request.seqs[0].kv_write_start = 7;
+        request.seqs[0].kv_len_after = 11;
+        request.seqs[0].block_table.extend(0..10);
+        request.draft_tokens.push(vec![11, 12, 13]);
+        let mut retained = StepRequest::workspace(1, 4, 16);
+        let ids = retained.seqs[0].input_ids.as_ptr();
+        let blocks = retained.seqs[0].block_table.as_ptr();
+        for n in [1, 4, 2] {
+            retained.retain_from(&request, &[n]);
+            assert_eq!(
+                retained.seqs[0].input_ids,
+                request.seqs[0].input_ids[..n as usize]
+            );
+            assert_eq!(retained.seqs[0].kv_len_after, 7 + n as i32);
+            assert!(retained.draft_tokens.is_empty());
+            assert_eq!(retained.seqs[0].input_ids.as_ptr(), ids);
+            assert_eq!(retained.seqs[0].block_table.as_ptr(), blocks);
+        }
+        assert_eq!(request.seqs[0].input_ids.len(), 4);
+        assert_eq!(request.draft_tokens[0], [11, 12, 13]);
+    }
+}

--- a/crates/infer-worker/src/domain/speculative.rs
+++ b/crates/infer-worker/src/domain/speculative.rs
@@ -1,0 +1,125 @@
+//! Contracts shared by speculative proposers, verifiers, and state committers.
+
+use std::ops::Range;
+
+use crate::domain::ports::{OpError, OpResult, SampledToken};
+
+/// A verification decision; it does not commit or mutate model state.
+///
+/// The target consumes `[pending, draft_1, ..., draft_K]`. If `r` drafts
+/// are accepted, the committer retains `1 + r` input positions, emits the
+/// accepted drafts followed by `correction_or_bonus`, and leaves that last
+/// token pending for the next target step.
+#[derive(Debug, Clone)]
+pub struct Verification {
+    pub accepted_drafts: usize,
+    pub correction_or_bonus: SampledToken,
+}
+
+/// A validated, borrowed ragged batch: K drafts require K + 1 target rows.
+/// An empty draft slice for an individual sequence represents K = 0.
+#[derive(Debug, Clone, Copy)]
+pub struct DraftBatch<'a> {
+    drafts: &'a [Vec<i32>],
+    q_lens: &'a [i32],
+    target_rows: usize,
+}
+
+#[derive(Debug)]
+pub struct DraftSequence<'a> {
+    pub drafts: &'a [i32],
+    pub target_rows: Range<usize>,
+}
+
+impl<'a> DraftBatch<'a> {
+    pub fn new(drafts: &'a [Vec<i32>], q_lens: &'a [i32], target_rows: usize) -> OpResult<Self> {
+        if drafts.is_empty() || drafts.len() != q_lens.len() {
+            return Err(OpError::Shape(format!(
+                "DraftBatch: {} draft sequences require the same nonzero number of q_lens, got {}",
+                drafts.len(),
+                q_lens.len()
+            )));
+        }
+        let mut rows = 0usize;
+        for (seq, (draft, &q_len)) in drafts.iter().zip(q_lens).enumerate() {
+            let required = draft
+                .len()
+                .checked_add(1)
+                .ok_or_else(|| OpError::Shape("DraftBatch: draft length overflow".into()))?;
+            if q_len <= 0 || q_len as usize != required {
+                return Err(OpError::Shape(format!(
+                    "DraftBatch: sequence {seq} has {} drafts; requires {required} target rows, got {q_len}",
+                    draft.len()
+                )));
+            }
+            rows = rows
+                .checked_add(required)
+                .ok_or_else(|| OpError::Shape("DraftBatch: target row offset overflow".into()))?;
+        }
+        if rows != target_rows {
+            return Err(OpError::Shape(format!(
+                "DraftBatch: requires {rows} target rows, got {target_rows}"
+            )));
+        }
+        Ok(Self {
+            drafts,
+            q_lens,
+            target_rows,
+        })
+    }
+
+    pub fn batch_size(self) -> usize {
+        self.drafts.len()
+    }
+
+    pub fn target_rows(self) -> usize {
+        self.target_rows
+    }
+
+    /// The checked constructor guarantees non-overlapping, in-bounds ranges.
+    pub fn sequences(self) -> impl Iterator<Item = DraftSequence<'a>> {
+        self.drafts
+            .iter()
+            .zip(self.q_lens)
+            .scan(0usize, |offset, (drafts, &q_len)| {
+                let start = *offset;
+                *offset += q_len as usize;
+                Some(DraftSequence {
+                    drafts,
+                    target_rows: start..*offset,
+                })
+            })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn ragged_ranges_include_one_extra_row_for_each_sequence() {
+        let drafts = vec![vec![1, 2], vec![], vec![3]];
+        let batch = DraftBatch::new(&drafts, &[3, 1, 2], 6).unwrap();
+        assert_eq!(batch.batch_size(), 3);
+        assert_eq!(batch.target_rows(), 6);
+        assert_eq!(
+            batch
+                .sequences()
+                .map(|seq| seq.target_rows)
+                .collect::<Vec<_>>(),
+            vec![0..3, 3..4, 4..6]
+        );
+    }
+
+    #[test]
+    fn malformed_layouts_fail_before_any_prediction_access() {
+        assert!(DraftBatch::new(&[], &[], 0).is_err());
+        assert!(DraftBatch::new(&[vec![]], &[], 1).is_err());
+        assert!(DraftBatch::new(&[vec![]], &[0], 0).is_err());
+        assert!(DraftBatch::new(&[vec![]], &[-1], 0).is_err());
+        assert!(DraftBatch::new(&[vec![1]], &[1], 1).is_err());
+        assert!(DraftBatch::new(&[vec![1]], &[3], 3).is_err());
+        assert!(DraftBatch::new(&[vec![1]], &[2], 1).is_err());
+        assert!(DraftBatch::new(&[vec![1]], &[2], 3).is_err());
+    }
+}

--- a/crates/infer-worker/src/models/decoder.rs
+++ b/crates/infer-worker/src/models/decoder.rs
@@ -25,7 +25,7 @@ use crate::domain::dtype::Dtype;
 use crate::domain::exec::StepCtx;
 use crate::domain::forward_scratch::ForwardScratch;
 use crate::domain::gdn_scratch::GdnScratch;
-use crate::domain::model::{DecoderModel, Logits, ModelDims, SampleRows};
+use crate::domain::model::{DecoderModel, DecoderReadout, Logits, ModelDims, SampleRows};
 use crate::domain::ports::backend::LlmBackend;
 use crate::domain::ports::{OpBackend, OpError, OpResult};
 use crate::domain::tensor::Tensor;
@@ -205,6 +205,11 @@ impl<T: Dtype, D: LlmBackend, F: DecoderFfn<T, D>> DecoderModel<T, D> for Decode
         rows: SampleRows<'_>,
         ctx: &StepCtx<'_, D>,
     ) -> OpResult<Logits<T, D>> {
+        if hidden.pending.is_some() {
+            return Err(OpError::Shape(
+                "readout requires a materialized residual".into(),
+            ));
+        }
         let num_tokens = hidden.num_tokens();
         let dev = hidden.stream.device().clone();
         let dim = self.dims.dim;
@@ -236,7 +241,10 @@ impl<T: Dtype, D: LlmBackend, F: DecoderFfn<T, D>> DecoderModel<T, D> for Decode
                 }
             }
             SampleRows::Explicit(sel) => {
-                if sel.len() >= num_tokens {
+                if sel.iter().any(|&i| i < 0 || i as usize >= num_tokens) {
+                    return Err(OpError::Shape("readout row out of bounds".into()));
+                }
+                if sel.iter().copied().eq(0..num_tokens as i32) {
                     None
                 } else {
                     Some(sel.to_vec())
@@ -280,6 +288,48 @@ impl<T: Dtype, D: LlmBackend, F: DecoderFfn<T, D>> DecoderModel<T, D> for Decode
         self.norm.forward(src, &mut normed, ctx)?;
         self.lm_head.forward(&normed, &mut logits, ctx)?;
         Ok(Logits(logits))
+    }
+}
+
+impl<T: Dtype, D: LlmBackend, F: DecoderFfn<T, D>> DecoderReadout<T, D> for Decoder<T, D, F> {
+    fn normalize_hidden_into(
+        &self,
+        hidden: &Hidden<T, D>,
+        output: &mut Tensor<T, D>,
+        ctx: &StepCtx<'_, D>,
+    ) -> OpResult<()> {
+        if hidden.pending.is_some()
+            || hidden.stream.shape().as_slice() != [ctx.plan().num_tokens, self.dims.dim]
+            || output.shape() != hidden.stream.shape()
+            || !output.is_contiguous()
+            || !hidden.stream.is_contiguous()
+        {
+            return Err(OpError::Shape(
+                "target readout requires materialized [tokens, dim] hidden and matching output"
+                    .into(),
+            ));
+        }
+        self.norm.forward(&hidden.stream, output, ctx)
+    }
+
+    fn project_logits_into(
+        &self,
+        normalized: &Tensor<T, D>,
+        output: &mut Tensor<T, D>,
+        ctx: &StepCtx<'_, D>,
+    ) -> OpResult<()> {
+        let shape = normalized.shape().as_slice();
+        if shape.len() != 2
+            || shape[1] != self.dims.dim
+            || output.shape().as_slice() != [shape[0], self.dims.vocab_size]
+            || !normalized.is_contiguous()
+            || !output.is_contiguous()
+        {
+            return Err(OpError::Shape(
+                "readout projection shape/layout mismatch".into(),
+            ));
+        }
+        self.lm_head.forward(normalized, output, ctx)
     }
 }
 
@@ -655,6 +705,74 @@ mod tests {
         };
         let _ = n;
         runner.step(&req).unwrap().tokens[0][0].token_id
+    }
+
+    #[test]
+    fn readout_composition_preserves_rows_and_owned_hidden() {
+        use crate::domain::plan::{BatchKind, BatchPlan};
+        let mut model = tiny_decoder();
+        model.install_scratch(ForwardScratch::new(&Cpu, model.dims(), 3, 1).unwrap());
+        let scope = crate::domain::exec::HostScope::new(Cpu);
+        let plan = BatchPlan {
+            kind: BatchKind::Ragged,
+            num_tokens: 3,
+            batch: 1,
+            q_lens: vec![3],
+            kv_lens: vec![3],
+            seq_positions: vec![0],
+            rope_positions: vec![0, 1, 2],
+            max_blocks_per_seq: 3,
+            block_size: 1,
+            total_q_tiles: 1,
+        };
+        let ctx = StepCtx::new(&scope, &plan);
+        let mut hidden = Hidden {
+            stream: weight(3, DIM),
+            pending: None,
+        };
+        let mut normalized = Tensor::zeros([3, DIM], &Cpu).unwrap();
+        model
+            .normalize_hidden_into(&hidden, &mut normalized, &ctx)
+            .unwrap();
+        let saved = normalized.to_host_vec().unwrap();
+        let mut projected = Tensor::zeros([3, VOCAB], &Cpu).unwrap();
+        model
+            .project_logits_into(&normalized, &mut projected, &ctx)
+            .unwrap();
+        let all = model
+            .finalize(&hidden, SampleRows::All, &ctx)
+            .unwrap()
+            .0
+            .to_host_vec()
+            .unwrap();
+        assert_eq!(projected.to_host_vec().unwrap(), all);
+        let selected = model
+            .finalize(&hidden, SampleRows::Explicit(&[2, 0, 2]), &ctx)
+            .unwrap()
+            .0
+            .to_host_vec()
+            .unwrap();
+        assert_eq!(
+            selected,
+            [&all[2 * VOCAB..], &all[..VOCAB], &all[2 * VOCAB..]].concat()
+        );
+        assert!(
+            model
+                .finalize(&hidden, SampleRows::Explicit(&[-1]), &ctx)
+                .is_err()
+        );
+        assert!(
+            model
+                .finalize(&hidden, SampleRows::Explicit(&[3]), &ctx)
+                .is_err()
+        );
+        hidden.pending = Some(weight(3, DIM));
+        assert!(
+            model
+                .normalize_hidden_into(&hidden, &mut normalized, &ctx)
+                .is_err()
+        );
+        assert_eq!(normalized.to_host_vec().unwrap(), saved);
     }
 
     /// Component forward correctness: a ragged 2-sequence prefill must produce

--- a/crates/infer-worker/src/models/qwen3_5.rs
+++ b/crates/infer-worker/src/models/qwen3_5.rs
@@ -1,5 +1,6 @@
 //! Qwen3.5 hybrid decoder with an optional vision encoder.
 
+pub mod mtp;
 pub mod vision;
 
 use crate::components::{
@@ -383,6 +384,25 @@ fn load_norm<T: Dtype, D: OpBackend + LlmBackend>(
     })
 }
 
+impl<T: Dtype, D: LlmBackend> crate::domain::model::DecoderReadout<T, D> for Qwen3_5Model<T, D> {
+    fn normalize_hidden_into(
+        &self,
+        hidden: &crate::domain::component::Hidden<T, D>,
+        output: &mut Tensor<T, D>,
+        ctx: &crate::domain::exec::StepCtx<'_, D>,
+    ) -> OpResult<()> {
+        self.decoder.normalize_hidden_into(hidden, output, ctx)
+    }
+    fn project_logits_into(
+        &self,
+        normalized: &Tensor<T, D>,
+        output: &mut Tensor<T, D>,
+        ctx: &crate::domain::exec::StepCtx<'_, D>,
+    ) -> OpResult<()> {
+        self.decoder.project_logits_into(normalized, output, ctx)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -393,7 +413,7 @@ mod tests {
     use safetensors::{Dtype as SafeDtype, tensor::TensorView};
     use std::collections::BTreeMap;
 
-    fn config() -> LoadConfig {
+    pub(super) fn config() -> LoadConfig {
         LoadConfig {
             dim: 8,
             intermediate_size: 16,
@@ -426,8 +446,7 @@ mod tests {
         }
     }
 
-    #[test]
-    fn builds_checkpoint_layout_and_ties_embeddings() {
+    pub(super) fn checkpoint(mtp: bool) -> SafetensorsReader {
         let mut tensors = BTreeMap::new();
         let mut add = |name: String, shape: Vec<usize>, value: f32| {
             let bytes: Vec<u8> = (0..shape.iter().product::<usize>())
@@ -476,6 +495,30 @@ mod tests {
                 }
             }
         }
+        if mtp {
+            for (name, shape) in [
+                ("fc", vec![8, 16]),
+                ("pre_fc_norm_embedding", vec![8]),
+                ("pre_fc_norm_hidden", vec![8]),
+                ("norm", vec![8]),
+                ("layers.0.input_layernorm", vec![8]),
+                ("layers.0.post_attention_layernorm", vec![8]),
+                ("layers.0.self_attn.q_proj", vec![16, 8]),
+                ("layers.0.self_attn.k_proj", vec![4, 8]),
+                ("layers.0.self_attn.v_proj", vec![4, 8]),
+                ("layers.0.self_attn.o_proj", vec![8, 8]),
+                ("layers.0.self_attn.q_norm", vec![4]),
+                ("layers.0.self_attn.k_norm", vec![4]),
+                ("layers.0.mlp.gate_proj", vec![16, 8]),
+                ("layers.0.mlp.up_proj", vec![16, 8]),
+                ("layers.0.mlp.down_proj", vec![8, 16]),
+            ] {
+                let bytes = (0..shape.iter().product::<usize>())
+                    .flat_map(|i| (((i * 7 % 19) as f32 - 9.) * 0.035).to_le_bytes())
+                    .collect();
+                tensors.insert(format!("mtp.{name}.weight"), (shape, bytes));
+            }
+        }
         let views: BTreeMap<_, _> = tensors
             .iter()
             .map(|(name, (shape, bytes))| {
@@ -486,12 +529,20 @@ mod tests {
             })
             .collect();
         let path = std::env::temp_dir().join(format!(
-            "rustinfer-qwen35-{}.safetensors",
-            std::process::id()
+            "rustinfer-qwen35-{}-{}-{:?}.safetensors",
+            std::process::id(),
+            mtp,
+            std::thread::current().id()
         ));
         safetensors::tensor::serialize_to_file(views, None, &path).unwrap();
         let reader = SafetensorsReader::open(&path).unwrap();
         std::fs::remove_file(&path).unwrap();
+        reader
+    }
+
+    #[test]
+    fn builds_checkpoint_layout_and_ties_embeddings() {
+        let reader = checkpoint(false);
         let loader = WeightLoader::new(&reader);
         let cfg = config();
         let model = build::<f32, Cpu>(&loader, &cfg, &Cpu).unwrap();

--- a/crates/infer-worker/src/models/qwen3_5/mtp.rs
+++ b/crates/infer-worker/src/models/qwen3_5/mtp.rs
@@ -1,0 +1,443 @@
+//! Qwen3.5 MTP checkpoint convention. Loaded explicitly, never by base build.
+use super::*;
+use crate::components::Embed;
+use crate::components::mtp::MtpHead;
+use crate::domain::model::DecoderModel;
+
+#[derive(Debug, serde::Deserialize)]
+pub struct MtpConfig {
+    pub mtp_num_hidden_layers: usize,
+    pub mtp_use_dedicated_embeddings: bool,
+}
+
+impl<T: Dtype, D: OpBackend + LlmBackend> Qwen3_5Model<T, D> {
+    /// Share immutable embedding and LM head storage with the target.
+    /// The returned head has its own workspace and requires an independent KV pool.
+    pub fn load_mtp(
+        &self,
+        loader: &WeightLoader<'_>,
+        cfg: &LoadConfig,
+        mtp: &MtpConfig,
+    ) -> OpResult<MtpHead<T, D, Decoder<T, D>>> {
+        let device = self.decoder.embed.table.device();
+        if mtp.mtp_num_hidden_layers != 1
+            || mtp.mtp_use_dedicated_embeddings
+            || loader.tensor_parallel().size != 1
+            || cfg.num_experts != 0
+            || cfg.mlp_quant.is_some()
+            || cfg.fp8_block.is_some()
+        {
+            return Err(OpError::unsupported(
+                "Qwen3.5 MTP",
+                "requires one dense layer, shared embeddings, TP1 and unquantized weights",
+            ));
+        }
+        let dims = self.dims();
+        if cfg.dim != dims.dim
+            || cfg.head_num != dims.head_num
+            || cfg.kv_head_num != dims.kv_head_num
+            || cfg.head_dim != dims.head_dim
+            || cfg.vocab_size != dims.vocab_size
+            || cfg.intermediate_size != dims.intermediate_size
+            || cfg.rotary_dim != self.rotary_dim
+            || cfg.rope_theta != self.rope_theta
+            || cfg.rms_norm_eps != self.decoder.norm.eps
+        {
+            return Err(OpError::Shape(
+                "MTP configuration does not match target".into(),
+            ));
+        }
+        let norm = |name: &str| load_norm(loader, name, cfg.dim, cfg.rms_norm_eps, device);
+        let embedding_norm = norm("mtp.pre_fc_norm_embedding.weight")?;
+        let hidden_norm = norm("mtp.pre_fc_norm_hidden.weight")?;
+        let fc = load_linear(loader, "mtp.fc.weight", cfg.dim, 2 * cfg.dim, device)?;
+        let (sin, cos) = compute_rope_cache(
+            cfg.seq_len,
+            cfg.rotary_dim,
+            cfg.rope_theta,
+            cfg.rope_scaling.as_ref(),
+            device,
+        )?;
+        let layer = "mtp.layers.0";
+        let block = DecoderBlock {
+            attention: Attention::Full(load_full_attention(
+                loader,
+                cfg,
+                layer,
+                norm("mtp.layers.0.input_layernorm.weight")?,
+                &sin,
+                &cos,
+                device,
+            )?),
+            ffn: load_dense_ffn(loader, cfg, layer, device)?,
+        };
+        let embedding = &self.decoder.embed;
+        let proj = &self.decoder.lm_head.proj;
+        let weight = proj
+            .weight
+            .as_dense()
+            .ok_or_else(|| OpError::unsupported("Qwen3.5 MTP", "quantized shared LM head"))?;
+        let decoder = Decoder::new(
+            Embed::new(embedding.table.clone()).with_parallelism(embedding.parallelism()),
+            vec![block],
+            norm("mtp.norm.weight")?,
+            LmHead {
+                proj: Linear::new(weight.clone(), proj.bias.clone())
+                    .with_parallelism(proj.parallelism()),
+            },
+            ModelDims {
+                num_layers: 1,
+                ..dims
+            },
+        )?;
+        Ok(MtpHead::new(embedding_norm, hidden_norm, fc, decoder))
+    }
+}
+
+fn load_full_attention<T: Dtype, D: OpBackend + LlmBackend>(
+    loader: &WeightLoader<'_>,
+    cfg: &LoadConfig,
+    layer: &str,
+    input_layernorm: RmsNorm<T, D>,
+    sin: &Tensor<T, D>,
+    cos: &Tensor<T, D>,
+    device: &D,
+) -> OpResult<FullAttention<T, D>> {
+    let q_dim = cfg.head_num * cfg.head_dim;
+    let kv_dim = cfg.kv_head_num * cfg.head_dim;
+    Ok(FullAttention {
+        input_layernorm,
+        qkv_proj: loader.load_fused_qkv_with_fp8(
+            layer,
+            q_dim * (1 + usize::from(cfg.attn_output_gate)),
+            kv_dim,
+            cfg.dim,
+            None,
+            device,
+        )?,
+        o_proj: load_linear(
+            loader,
+            &format!("{layer}.self_attn.o_proj.weight"),
+            cfg.dim,
+            q_dim,
+            device,
+        )?,
+        q_norm: Some(load_norm(
+            loader,
+            &format!("{layer}.self_attn.q_norm.weight"),
+            cfg.head_dim,
+            cfg.rms_norm_eps,
+            device,
+        )?),
+        k_norm: Some(load_norm(
+            loader,
+            &format!("{layer}.self_attn.k_norm.weight"),
+            cfg.head_dim,
+            cfg.rms_norm_eps,
+            device,
+        )?),
+        sin: sin.clone(),
+        cos: cos.clone(),
+        head_num: cfg.head_num,
+        kv_head_num: cfg.kv_head_num,
+        head_dim: cfg.head_dim,
+        rotary_dim: cfg.rotary_dim,
+        attn_output_gate: cfg.attn_output_gate,
+        scale: 1.0 / (cfg.head_dim as f32).sqrt(),
+        scratch: None,
+    })
+}
+fn load_dense_ffn<T: Dtype, D: OpBackend + LlmBackend>(
+    loader: &WeightLoader<'_>,
+    cfg: &LoadConfig,
+    layer: &str,
+    device: &D,
+) -> OpResult<DenseFfn<T, D>> {
+    Ok(DenseFfn {
+        post_attention_layernorm: load_norm(
+            loader,
+            &format!("{layer}.post_attention_layernorm.weight"),
+            cfg.dim,
+            cfg.rms_norm_eps,
+            device,
+        )?,
+        gate_up_proj: loader.load_fused_gate_up_with_fp8(
+            layer,
+            cfg.intermediate_size,
+            cfg.dim,
+            None,
+            device,
+        )?,
+        down_proj: load_linear(
+            loader,
+            &format!("{layer}.mlp.down_proj.weight"),
+            cfg.dim,
+            cfg.intermediate_size,
+            device,
+        )?,
+        scratch: None,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::application::speculative::prefill::MtpPrefill;
+    use crate::components::mtp::MtpInput;
+    use crate::domain::cache::ModelCacheView;
+    use crate::domain::exec::StepCtx;
+    use crate::domain::kv::{KvIndexTensors, KvQuantTier, PagedKvLayer, PagedKvPool};
+    use crate::domain::plan::{BatchKind, BatchPlan};
+    use crate::domain::tensor::Tensor;
+
+    #[test]
+    fn eager_session_handles_chunked_prefill_budgets_eos_and_reuse() {
+        use crate::application::speculative::{MtpLimits, MtpSession};
+        use crate::domain::exec::HostScope;
+        use crate::infrastructure::cpu::Cpu;
+        let mut cfg = super::super::tests::config();
+        cfg.seq_len = 32;
+        let reader = super::super::tests::checkpoint(true);
+        let loader = WeightLoader::new(&reader);
+        for context in [6, 32] {
+            for (k, max_step) in [(0, 1), (1, 2), (3, 4)] {
+                for (budget, eos) in [(1, vec![]), (8, vec![]), (8, vec![0])] {
+                    let model = build::<f32, Cpu>(&loader, &cfg, &Cpu).unwrap();
+                    let head = model
+                        .load_mtp(
+                            &loader,
+                            &cfg,
+                            &MtpConfig {
+                                mtp_num_hidden_layers: 1,
+                                mtp_use_dedicated_embeddings: false,
+                            },
+                        )
+                        .unwrap();
+                    let mut session = MtpSession::new(
+                        model,
+                        head,
+                        HostScope::new(Cpu),
+                        MtpLimits {
+                            max_context: context,
+                            max_step_tokens: max_step,
+                            max_output_tokens: budget,
+                            draft_tokens: k,
+                            eos_ids: eos.clone(),
+                        },
+                    )
+                    .unwrap();
+                    assert!(session.decode().is_err());
+                    assert!(session.prefill(&[-1]).is_err());
+                    for prompt in [&[1, 2, 3, 4, 5][..], &[3][..]] {
+                        session.reset().unwrap();
+                        let mut step = session.prefill(prompt).unwrap();
+                        assert!(session.prefill(prompt).is_err());
+                        let mut tokens = step.tokens.clone();
+                        while !step.finished {
+                            step = session.decode().unwrap();
+                            assert_eq!(step.accepted, step.proposed);
+                            tokens.extend_from_slice(&step.tokens);
+                            assert_eq!(session.cached_tokens(), session.draft_cached_tokens() + 1);
+                        }
+                        assert_eq!(
+                            tokens,
+                            vec![
+                                0;
+                                if eos.is_empty() {
+                                    (budget as usize).min(context - prompt.len() + 1)
+                                } else {
+                                    1
+                                }
+                            ]
+                        );
+                        assert_eq!(session.cached_tokens(), prompt.len() + tokens.len() - 1);
+                        assert!(session.decode().is_err());
+                    }
+                }
+            }
+        }
+    }
+    fn indices<D: crate::domain::ports::backend::LlmBackend>(
+        start: usize,
+        n: usize,
+        blocks: usize,
+        device: &D,
+    ) -> (BatchPlan, KvIndexTensors<D>) {
+        let positions: Vec<i32> = (start as i32..(start + n) as i32).collect();
+        let (cu, req, tile) = BatchPlan::plan_ragged_tiles(&[n as i32]);
+        let plan = BatchPlan {
+            kind: if n == 1 {
+                BatchKind::DecodeOnly
+            } else {
+                BatchKind::Ragged
+            },
+            num_tokens: n,
+            batch: 1,
+            q_lens: vec![n as i32],
+            kv_lens: vec![(start + n) as i32],
+            seq_positions: vec![start as i32],
+            rope_positions: positions.clone(),
+            max_blocks_per_seq: blocks,
+            block_size: 1,
+            total_q_tiles: req.len() as i32,
+        };
+        let ints = |v: &[i32]| Tensor::from_host_slice(v, [v.len()], device).unwrap();
+        let idx = KvIndexTensors {
+            block_tables: Tensor::from_host_slice(
+                &(0..blocks as i32).collect::<Vec<_>>(),
+                [1, blocks],
+                device,
+            )
+            .unwrap(),
+            cu_q_lens: ints(&cu),
+            kv_lens: ints(&plan.kv_lens),
+            seq_positions: ints(&[start as i32]),
+            seq_lens_step: ints(&[n as i32]),
+            rope_positions: ints(&positions),
+            block2req: ints(&req),
+            block2tile: ints(&tile),
+            valid_q_tiles: ints(&[req.len() as i32]),
+            valid_suffix_q_tiles: ints(&[req.len() as i32]),
+        };
+        (plan, idx)
+    }
+    fn pool<T: crate::domain::dtype::Dtype, D: crate::domain::ports::backend::LlmBackend>(
+        layers: usize,
+        blocks: usize,
+        kv_dim: usize,
+        device: &D,
+    ) -> PagedKvPool<T, D> {
+        PagedKvPool {
+            layers: (0..layers)
+                .map(|_| PagedKvLayer {
+                    k: Tensor::zeros([blocks, 1, kv_dim], device).unwrap(),
+                    v: Tensor::zeros([blocks, 1, kv_dim], device).unwrap(),
+                })
+                .collect(),
+            num_blocks: blocks,
+            block_size: 1,
+            kv_dim,
+            quant: KvQuantTier::None,
+            seq_kv_len: Default::default(),
+        }
+    }
+
+    #[test]
+    fn loaded_head_matches_chunked_execution_and_rejects_unsupported_configs() {
+        use crate::infrastructure::cpu::Cpu;
+        let cfg = super::super::tests::config();
+        let reader = super::super::tests::checkpoint(true);
+        let loader = WeightLoader::new(&reader);
+        let model = build::<f32, Cpu>(&loader, &cfg, &Cpu).unwrap();
+        let mtp = MtpConfig {
+            mtp_num_hidden_layers: 1,
+            mtp_use_dedicated_embeddings: false,
+        };
+        let mut head = model.load_mtp(&loader, &cfg, &mtp).unwrap();
+        assert_eq!(head.cache_layout().num_full_layers(), 1);
+        assert!(head.cache_layout().linear_dims().is_empty());
+        assert!(
+            model
+                .load_mtp(
+                    &loader,
+                    &cfg,
+                    &MtpConfig {
+                        mtp_num_hidden_layers: 2,
+                        ..mtp
+                    },
+                )
+                .is_err()
+        );
+        assert!(
+            model
+                .load_mtp(
+                    &loader,
+                    &cfg,
+                    &MtpConfig {
+                        mtp_use_dedicated_embeddings: true,
+                        ..mtp
+                    },
+                )
+                .is_err()
+        );
+        let missing = super::super::tests::checkpoint(false);
+        assert!(
+            model
+                .load_mtp(&WeightLoader::new(&missing), &cfg, &mtp)
+                .is_err()
+        );
+        let mut bad_cfg = cfg.clone();
+        bad_cfg.dim += 1;
+        assert!(model.load_mtp(&loader, &bad_cfg, &mtp).is_err());
+        head.prepare(5, 1).unwrap();
+        let ids = [1, 2, 3, 4, 5];
+        let target = Tensor::from_host_slice(
+            &(0..40).map(|i| (i as f32 - 20.) / 11.).collect::<Vec<_>>(),
+            [5, 8],
+            &Cpu,
+        )
+        .unwrap();
+        let scope = crate::domain::exec::HostScope::new(Cpu);
+        let mut expected: Option<Vec<f32>> = None;
+        for cuts in [vec![5], vec![1, 2, 3, 4, 5], vec![2, 4, 5]] {
+            let mut kv = pool(1, 8, 4, &Cpu);
+            let mut align = MtpPrefill::default();
+            let mut actual = Vec::new();
+            let mut start = 0;
+            for end in cuts {
+                let positions: Vec<_> = (start as i32..end as i32).collect();
+                let chunk = align
+                    .prepare(
+                        &ids[start..end],
+                        &positions,
+                        &target.narrow(0, start, end - start).unwrap(),
+                    )
+                    .unwrap();
+                let n = chunk.next_token_ids.len();
+                if n > 0 {
+                    let (plan, index) = indices(chunk.positions[0] as usize, n, 8, &Cpu);
+                    let ctx = StepCtx::new(&scope, &plan);
+                    let mut output = Tensor::zeros([n, 8], &Cpu).unwrap();
+                    let tokens = Tensor::from_host_slice(&chunk.next_token_ids, [n], &Cpu).unwrap();
+                    let before = kv.layers[0].k.to_host_vec().unwrap();
+                    assert!(
+                        head.forward_hidden_into(
+                            MtpInput {
+                                next_token_ids: &tokens,
+                                target_hidden: &chunk.target_hidden
+                            },
+                            &mut ModelCacheView::full(&mut kv, &index),
+                            &mut Tensor::zeros([n, 9], &Cpu).unwrap(),
+                            &ctx,
+                        )
+                        .is_err()
+                    );
+                    assert_eq!(kv.layers[0].k.to_host_vec().unwrap(), before);
+                    let mut cache = ModelCacheView::full(&mut kv, &index);
+                    head.forward_hidden_into(
+                        MtpInput {
+                            next_token_ids: &tokens,
+                            target_hidden: &chunk.target_hidden,
+                        },
+                        &mut cache,
+                        &mut output,
+                        &ctx,
+                    )
+                    .unwrap();
+                    actual.extend(output.to_host_vec().unwrap());
+                }
+                chunk.commit();
+                start = end;
+            }
+            if let Some(ref expected) = expected {
+                assert_eq!(actual.len(), expected.len());
+                for (&a, &b) in actual.iter().zip(expected) {
+                    assert!((a - b).abs() < 1e-5, "{a} != {b}");
+                }
+            } else {
+                expected = Some(actual);
+            }
+        }
+        assert!(expected.unwrap().iter().all(|x| x.is_finite()));
+    }
+}

--- a/crates/infer-worker/tests/hybrid_decoder.rs
+++ b/crates/infer-worker/tests/hybrid_decoder.rs
@@ -622,6 +622,8 @@ fn hybrid_verification_restores_every_rejected_prefix_and_continues_greedy() {
                 tape.push(next);
             }
             let mut actual = hybrid_runtime(1);
+            use infer_worker::application::execution::{ExecutionMetrics, Phase};
+            actual.execution_metrics = ExecutionMetrics::new("test-target", 100);
             let mut reference = hybrid_runtime(1);
             let prefill = request(&[(10, 0, 0, &[1, 2, 3])]);
             actual.step(&prefill).unwrap();
@@ -634,6 +636,20 @@ fn hybrid_verification_restores_every_rejected_prefix_and_continues_greedy() {
             verify.draft_tokens = vec![inputs[1..].to_vec()];
             let result = actual.step_with_hidden(&verify).unwrap();
             assert_eq!(result.output.accepted_drafts, Some(vec![accepted as u32]));
+            assert_eq!(actual.execution_metrics.snapshot(Phase::Verify).calls, 1);
+            assert_eq!(actual.execution_metrics.snapshot(Phase::Snapshot).calls, 1);
+            assert_eq!(
+                actual.execution_metrics.snapshot(Phase::Restore).calls,
+                u64::from(accepted < k)
+            );
+            assert_eq!(
+                actual.execution_metrics.snapshot(Phase::Replay).tokens,
+                if accepted < k {
+                    (accepted + 1) as u64
+                } else {
+                    0
+                }
+            );
             assert_eq!(result.output.materialized_tokens, vec![accepted as u32 + 1]);
             assert_eq!(
                 result.output.tokens[0]

--- a/crates/infer-worker/tests/hybrid_decoder.rs
+++ b/crates/infer-worker/tests/hybrid_decoder.rs
@@ -19,7 +19,8 @@ use infer_worker::domain::forward_scratch::ForwardScratch;
 use infer_worker::domain::gdn_scratch::GdnScratch;
 use infer_worker::domain::kv::{KvIndexTensors, KvQuantTier, PagedKvLayer, PagedKvPool};
 use infer_worker::domain::model::{DecoderModel, ModelDims};
-use infer_worker::domain::plan::{BatchKind, BatchPlan, MaskMode};
+use infer_worker::domain::plan::{BatchKind, BatchPlan, MaskMode, StepOutput, StepRequest};
+use infer_worker::domain::ports::OpResult;
 use infer_worker::domain::tensor::Tensor;
 use infer_worker::infrastructure::cpu::Cpu;
 use infer_worker::models::decoder::Decoder;
@@ -599,6 +600,207 @@ fn hybrid_runtime(capacity: usize) -> Runtime<f32, Cpu, Decoder<f32, Cpu>> {
     .unwrap()
 }
 
+#[test]
+fn hybrid_verification_restores_every_rejected_prefix_and_continues_greedy() {
+    // Sweep K=0 and rejection at every possible draft position, including
+    // full acceptance. Continuation checks both full KV and all recurrent layers.
+    for k in 0..=3 {
+        for accepted in 0..=k {
+            let mut oracle = hybrid_runtime(1);
+            let first = oracle
+                .step(&request(&[(10, 0, 0, &[1, 2, 3])]))
+                .unwrap()
+                .tokens[0][0]
+                .token_id;
+            let mut tape = vec![first];
+            for i in 0..k + 3 {
+                let next = oracle
+                    .step(&request(&[(10, 0, 3 + i, &[tape[i]])]))
+                    .unwrap()
+                    .tokens[0][0]
+                    .token_id;
+                tape.push(next);
+            }
+            let mut actual = hybrid_runtime(1);
+            let mut reference = hybrid_runtime(1);
+            let prefill = request(&[(10, 0, 0, &[1, 2, 3])]);
+            actual.step(&prefill).unwrap();
+            reference.step(&prefill).unwrap();
+            let mut inputs = tape[..k + 1].to_vec();
+            if accepted < k {
+                inputs[accepted + 1] = (inputs[accepted + 1] + 1) % VOCAB as i32;
+            }
+            let mut verify = request(&[(10, 0, 3, &inputs)]);
+            verify.draft_tokens = vec![inputs[1..].to_vec()];
+            let result = actual.step_with_hidden(&verify).unwrap();
+            assert_eq!(result.output.accepted_drafts, Some(vec![accepted as u32]));
+            assert_eq!(result.output.materialized_tokens, vec![accepted as u32 + 1]);
+            assert_eq!(
+                result.output.tokens[0]
+                    .iter()
+                    .map(|t| t.token_id)
+                    .collect::<Vec<_>>(),
+                tape[1..accepted + 2]
+            );
+            let expected = reference
+                .step_with_hidden(&request(&[(10, 0, 3, &tape[..accepted + 1])]))
+                .unwrap();
+            close(
+                &result.normalized_hidden.to_host_vec().unwrap(),
+                &expected.normalized_hidden.to_host_vec().unwrap(),
+            );
+            let saved = result.normalized_hidden.to_host_vec().unwrap();
+            for (i, &token) in tape.iter().enumerate().skip(accepted + 1).take(2) {
+                let req = request(&[(10, 0, 3 + i, &[token])]);
+                let a = actual.step(&req).unwrap();
+                let b = reference.step(&req).unwrap();
+                assert_runtime_outputs_match(&actual, &reference, &a, &b, 1);
+            }
+            assert_eq!(result.normalized_hidden.to_host_vec().unwrap(), saved);
+        }
+    }
+}
+
+#[test]
+fn hybrid_verification_eos_and_reordered_ragged_requests_commit_only_retained_history() {
+    let mut actual = hybrid_runtime(2);
+    let mut reference = hybrid_runtime(2);
+    let prefill = request(&[(10, 0, 0, &[1, 2]), (20, 1, 0, &[3])]);
+    actual.step(&prefill).unwrap();
+    reference.step(&prefill).unwrap();
+    // The first sequence has K=0; the other has a longer speculative suffix.
+    let mut req = request(&[(20, 1, 1, &[4]), (10, 0, 2, &[5, 6, 7])]);
+    req.draft_tokens = vec![vec![], vec![6, 7]];
+    // Make every possible first output an EOS, testing truncation independently
+    // of this synthetic model's token predictions.
+    req.stop.eos_ids = (0..VOCAB as i32).collect();
+    req.stop.ignore_eos = vec![false, false];
+    let out = actual.step_with_hidden(&req).unwrap();
+    assert_eq!(out.output.materialized_tokens, [1, 1]);
+    assert_eq!(out.output.finished, [true, true]);
+    let retained = request(&[(20, 1, 1, &[4]), (10, 0, 2, &[5])]);
+    let expected = reference.step_with_hidden(&retained).unwrap();
+    close(
+        &out.normalized_hidden.to_host_vec().unwrap(),
+        &expected.normalized_hidden.to_host_vec().unwrap(),
+    );
+    let next = request(&[(10, 0, 3, &[8]), (20, 1, 2, &[9])]);
+    let a = actual.step(&next).unwrap();
+    let b = reference.step(&next).unwrap();
+    assert_runtime_outputs_match(&actual, &reference, &a, &b, 2);
+}
+
+#[test]
+fn failed_recurrent_replay_invalidates_the_request_until_reprefill() {
+    use infer_worker::domain::model::{Logits, SampleRows};
+    use infer_worker::domain::ports::OpError;
+    use std::cell::Cell;
+    struct FailReplay {
+        decoder: Decoder<f32, Cpu>,
+        calls: Cell<usize>,
+        fail_at: Cell<usize>,
+    }
+    impl DecoderModel<f32, Cpu> for FailReplay {
+        fn dims(&self) -> ModelDims {
+            self.decoder.dims()
+        }
+        fn cache_layout(&self) -> &CacheLayout {
+            self.decoder.cache_layout()
+        }
+        fn stages(&self) -> &[infer_worker::domain::component::StageKind] {
+            self.decoder.stages()
+        }
+        fn install_scratch(&mut self, s: std::rc::Rc<ForwardScratch<f32, Cpu>>) {
+            self.decoder.install_scratch(s);
+        }
+        fn install_gdn_scratch(&mut self, s: std::rc::Rc<GdnScratch<f32, Cpu>>) -> OpResult<()> {
+            self.decoder.install_gdn_scratch(s)
+        }
+        fn embed(
+            &self,
+            ids: &Tensor<i32, Cpu>,
+            h: &mut Hidden<f32, Cpu>,
+            ctx: &StepCtx<'_, Cpu>,
+        ) -> OpResult<()> {
+            self.decoder.embed(ids, h, ctx)
+        }
+        fn decode_layers(
+            &self,
+            range: LayerRange,
+            h: &mut Hidden<f32, Cpu>,
+            cache: &mut ModelCacheView<'_, f32, Cpu>,
+            ctx: &StepCtx<'_, Cpu>,
+        ) -> OpResult<()> {
+            self.calls.set(self.calls.get() + 1);
+            self.decoder.decode_layers(range, h, cache, ctx)?;
+            if self.calls.get() == self.fail_at.get() {
+                return Err(OpError::Kernel("injected replay failure".into()));
+            }
+            Ok(())
+        }
+        fn finalize(
+            &self,
+            h: &Hidden<f32, Cpu>,
+            rows: SampleRows<'_>,
+            ctx: &StepCtx<'_, Cpu>,
+        ) -> OpResult<Logits<f32, Cpu>> {
+            self.decoder.finalize(h, rows, ctx)
+        }
+    }
+    let model = FailReplay {
+        decoder: model(false),
+        calls: Cell::new(0),
+        fail_at: Cell::new(3),
+    };
+    let mut runtime = Runtime::new(
+        model,
+        HostScope::new(Cpu),
+        Box::new(GreedySampler),
+        SLOTS * MAX_SEQ,
+        1,
+        MAX_SEQ,
+        MAX_SEQ,
+        32,
+        2,
+        vec![],
+    )
+    .unwrap();
+    let mut reference = hybrid_runtime(2);
+    let prefill = request(&[(10, 0, 0, &[1, 2]), (20, 1, 0, &[3])]);
+    runtime.step(&prefill).unwrap();
+    reference.step(&prefill).unwrap();
+    let mut req = request(&[(10, 0, 2, &[4, 5, 6])]);
+    req.draft_tokens = vec![vec![5, 6]];
+    req.stop.eos_ids = (0..VOCAB as i32).collect();
+    req.stop.ignore_eos = vec![false];
+    assert!(
+        runtime
+            .step(&req)
+            .unwrap_err()
+            .to_string()
+            .contains("injected replay failure")
+    );
+    assert!(runtime.step(&request(&[(10, 0, 3, &[7])])).is_err());
+    let next = request(&[(20, 1, 1, &[8])]);
+    let a = runtime.step(&next).unwrap();
+    let b = reference.step(&next).unwrap();
+    assert_eq!(a.tokens[0][0].token_id, b.tokens[0][0].token_id);
+    close(
+        &runtime.hidden.stream.to_host_vec().unwrap()[..DIM],
+        &reference.hidden.stream.to_host_vec().unwrap()[..DIM],
+    );
+    // Same id can recover from zero after the failed transaction.
+    reference.release_sequence(10);
+    let replay = request(&[(10, 0, 0, &[1, 2, 4])]);
+    let a = runtime.step(&replay).unwrap();
+    let b = reference.step(&replay).unwrap();
+    assert_eq!(a.tokens[0][0].token_id, b.tokens[0][0].token_id);
+    close(
+        &runtime.hidden.stream.to_host_vec().unwrap()[..3 * DIM],
+        &reference.hidden.stream.to_host_vec().unwrap()[..3 * DIM],
+    );
+}
+
 fn request(seqs: &[(u64, usize, usize, &[i32])]) -> infer_worker::domain::plan::StepRequest {
     use infer_worker::domain::plan::{SeqStep, StepRequest, StopCriteria};
     StepRequest {
@@ -624,6 +826,132 @@ fn request(seqs: &[(u64, usize, usize, &[i32])]) -> infer_worker::domain::plan::
         },
         draft_tokens: vec![],
     }
+}
+
+fn assert_runtime_outputs_match(
+    actual: &Runtime<f32, Cpu, Decoder<f32, Cpu>>,
+    expected: &Runtime<f32, Cpu, Decoder<f32, Cpu>>,
+    actual_out: &StepOutput,
+    expected_out: &StepOutput,
+    input_rows: usize,
+) {
+    let token_ids = |out: &StepOutput| {
+        out.tokens
+            .iter()
+            .map(|row| row.iter().map(|token| token.token_id).collect::<Vec<_>>())
+            .collect::<Vec<_>>()
+    };
+    assert_eq!(token_ids(actual_out), token_ids(expected_out));
+    assert_eq!(actual_out.finished, expected_out.finished);
+    close(
+        &actual.hidden.stream.to_host_vec().unwrap()[..input_rows * DIM],
+        &expected.hidden.stream.to_host_vec().unwrap()[..input_rows * DIM],
+    );
+    let rows = actual_out.tokens.len();
+    close(
+        &actual
+            .model
+            .scratch
+            .as_ref()
+            .unwrap()
+            .logits(rows)
+            .to_host_vec()
+            .unwrap(),
+        &expected
+            .model
+            .scratch
+            .as_ref()
+            .unwrap()
+            .logits(rows)
+            .to_host_vec()
+            .unwrap(),
+    );
+}
+
+fn assert_finalize_failure_invalidates_history(
+    new_tokens: &[i32],
+    fail: impl FnOnce(&mut Runtime<f32, Cpu, Decoder<f32, Cpu>>, &StepRequest) -> OpResult<()>,
+) {
+    let mut runtime = hybrid_runtime(2);
+    let mut reference = hybrid_runtime(2);
+    let prefill = request(&[(10, 0, 0, &[1, 2])]);
+    runtime.step(&prefill).unwrap();
+    reference.step(&prefill).unwrap();
+    let failed = request(&[(10, 0, 2, &[3]), (20, 1, 0, new_tokens)]);
+    reference.step(&failed).unwrap();
+
+    // Both the existing request and a newly assigned slot reach all decoder
+    // layers before the lm_head's incompatible input width rejects finalize.
+    let original = std::mem::replace(&mut runtime.model.lm_head.proj, linear(VOCAB, DIM + 1, 1.0));
+    assert!(fail(&mut runtime, &failed).is_err());
+    close(
+        &runtime.hidden.stream.to_host_vec().unwrap()[..(1 + new_tokens.len()) * DIM],
+        &reference.hidden.stream.to_host_vec().unwrap()[..(1 + new_tokens.len()) * DIM],
+    );
+    runtime.model.lm_head.proj = original;
+
+    // Neither the pre-step nor the would-be committed position can continue:
+    // kernels already changed persistent state, so the whole history is invalid.
+    for (id, slot, position) in [(10, 0, 2), (10, 0, 3), (20, 1, new_tokens.len())] {
+        let error = runtime
+            .step(&request(&[(id, slot, position, &[6])]))
+            .unwrap_err();
+        assert!(error.to_string().contains("recurrent history"), "{error}");
+    }
+
+    let mut fresh = hybrid_runtime(2);
+    for (req, rows) in [
+        (request(&[(20, 1, 0, &[7, 8]), (10, 0, 0, &[9])]), 3),
+        (request(&[(10, 0, 1, &[10]), (20, 1, 2, &[11])]), 2),
+    ] {
+        let actual = runtime.step(&req).unwrap();
+        let expected = fresh.step(&req).unwrap();
+        assert_runtime_outputs_match(&runtime, &fresh, &actual, &expected, rows);
+    }
+}
+
+#[test]
+fn runtime_hybrid_finalize_failure_invalidates_and_rebuilds_history() {
+    assert_finalize_failure_invalidates_history(&[4, 5], |runtime, req| {
+        runtime.step(req).map(|_| ())
+    });
+}
+
+#[test]
+fn runtime_hybrid_fused_finalize_failure_invalidates_and_rebuilds_history() {
+    assert_finalize_failure_invalidates_history(&[4, 5], |runtime, req| {
+        runtime.step_fused_eager(req).map(|_| ())
+    });
+}
+
+#[test]
+fn runtime_hybrid_mixed_issue_failure_invalidates_and_rebuilds_history() {
+    use infer_worker::application::runtime::RaggedRowKind;
+    assert_finalize_failure_invalidates_history(&[4, 5], |runtime, req| {
+        runtime
+            .issue_fused_abc(
+                req,
+                &[RaggedRowKind::Decode, RaggedRowKind::PrefillFinal],
+                None,
+            )
+            .map(|_| ())
+    });
+}
+
+#[test]
+fn runtime_hybrid_decode_issue_failure_invalidates_and_rebuilds_history() {
+    assert_finalize_failure_invalidates_history(&[4], |runtime, req| {
+        runtime.issue_decode_abc(
+            req,
+            0,
+            &[0, 0],
+            &[100, 100],
+            &[true, true],
+            &[],
+            None,
+            false,
+        )
+    });
 }
 
 #[test]
@@ -768,11 +1096,115 @@ fn runtime_hybrid_mixed_and_abc_use_the_same_request_history() {
         &runtime.hidden.stream.to_host_vec().unwrap()[..2 * DIM],
         &ordinary.hidden.stream.to_host_vec().unwrap()[..2 * DIM],
     );
-    let mut spec = request(&[(10, 0, 3, &[6])]);
-    spec.draft_tokens = vec![vec![6]];
-    assert!(runtime.step(&spec).is_err());
+    let mut spec = request(&[(10, 0, 3, &[6, 7])]);
+    // Stochastic verification remains unsupported and must fail before mutation.
+    spec.draft_tokens = vec![vec![7]];
+    spec.sampling[0].temperature = 1.0;
+    let error = runtime.step(&spec).unwrap_err();
+    assert!(error.to_string().contains("stochastic"), "{error}");
+    spec.sampling[0].temperature = 0.0;
     spec.draft_tokens.clear();
-    runtime.step(&spec).unwrap();
+    let actual = runtime.step(&spec).unwrap();
+    let expected = ordinary.step(&spec).unwrap();
+    assert_runtime_outputs_match(&runtime, &ordinary, &actual, &expected, 2);
+}
+
+#[test]
+fn runtime_hybrid_overlapped_decode_and_mixed_keep_committed_history() {
+    use infer_worker::application::runtime::RaggedRowKind;
+    let mut runtime = hybrid_runtime(2);
+    let mut ordinary = hybrid_runtime(2);
+    assert!(runtime.mixed_eager_mode());
+    let prefill = request(&[(10, 0, 0, &[1, 2])]);
+    runtime.step(&prefill).unwrap();
+    ordinary.step(&prefill).unwrap();
+
+    let decode = request(&[(10, 0, 2, &[3])]);
+    let expected_decode = ordinary.step(&decode).unwrap();
+    let next_token = expected_decode.tokens[0][0].token_id;
+    runtime
+        .issue_decode_abc(&decode, 0, &[0], &[100], &[true], &[], None, false)
+        .unwrap();
+
+    let mut verify = request(&[(10, 0, 3, &[next_token])]);
+    verify.draft_tokens = vec![vec![]];
+    assert!(
+        runtime
+            .step(&verify)
+            .unwrap_err()
+            .to_string()
+            .contains("in-flight")
+    );
+
+    let kinds = [RaggedRowKind::Decode, RaggedRowKind::PrefillFinal];
+    let mixed = request(&[(10, 0, 3, &[next_token]), (20, 1, 0, &[4, 5])]);
+    let expected_mixed = ordinary.step(&mixed).unwrap();
+    let mut placeholders = mixed.clone();
+    placeholders.seqs[0].input_ids[0] = (next_token + 1) % VOCAB as i32;
+    // The earlier decode still owns the host mirrors. Its GPU argmax feeds the
+    // mixed tape, while recurrent history must already expose its issued prefix.
+    let ticket = runtime
+        .issue_fused_abc_overlapped(&placeholders, &kinds, None, 1)
+        .unwrap();
+    let decoded = runtime.finalize_decode_abc(1).unwrap();
+    assert_eq!(decoded.active.len(), 1);
+    assert!(decoded.finished.is_empty());
+    assert_eq!(decoded.active[0].src_row, 0);
+    assert_eq!(decoded.active[0].token_id, next_token);
+    let actual_mixed = runtime
+        .finalize_fused_abc(ticket, &placeholders, &kinds)
+        .unwrap();
+    assert_runtime_outputs_match(&runtime, &ordinary, &actual_mixed, &expected_mixed, 3);
+
+    // Finalizing the earlier ticket must not reset the later step's length or
+    // discard a request admitted by that later step; reorder both on continuation.
+    let continuation = request(&[(20, 1, 2, &[7]), (10, 0, 4, &[8])]);
+    let actual = runtime.step(&continuation).unwrap();
+    let expected = ordinary.step(&continuation).unwrap();
+    assert_runtime_outputs_match(&runtime, &ordinary, &actual, &expected, 2);
+}
+
+#[test]
+fn runtime_hybrid_decode_collection_failure_invalidates_only_its_owners() {
+    use infer_worker::application::runtime::RaggedRowKind;
+    let mut runtime = hybrid_runtime(2);
+    let mut ordinary = hybrid_runtime(2);
+    let prefill = request(&[(10, 0, 0, &[1, 2])]);
+    runtime.step(&prefill).unwrap();
+    ordinary.step(&prefill).unwrap();
+    let decode = request(&[(10, 0, 2, &[3])]);
+    let next_token = ordinary.step(&decode).unwrap().tokens[0][0].token_id;
+    runtime
+        .issue_decode_abc(&decode, 0, &[0], &[100], &[true], &[], None, false)
+        .unwrap();
+
+    let kinds = [RaggedRowKind::Decode, RaggedRowKind::PrefillFinal];
+    let mixed = request(&[(10, 0, 3, &[next_token]), (20, 1, 0, &[4, 5])]);
+    ordinary.step(&mixed).unwrap();
+    let ticket = runtime
+        .issue_fused_abc_overlapped(&mixed, &kinds, None, 1)
+        .unwrap();
+    // A late collection error belongs to the earlier decode's owner set,
+    // even though another issue has since advanced shared/new histories.
+    let error = runtime.finalize_decode_abc(0).unwrap_err();
+    assert!(
+        error.to_string().contains("compact counts invalid"),
+        "{error}"
+    );
+    runtime.finalize_fused_abc(ticket, &mixed, &kinds).unwrap();
+    let error = runtime.step(&request(&[(10, 0, 4, &[6])])).unwrap_err();
+    assert!(error.to_string().contains("recurrent history"), "{error}");
+
+    let continuation = request(&[(20, 1, 2, &[7])]);
+    let actual = runtime.step(&continuation).unwrap();
+    let expected = ordinary.step(&continuation).unwrap();
+    assert_runtime_outputs_match(&runtime, &ordinary, &actual, &expected, 1);
+
+    let mut fresh = hybrid_runtime(1);
+    let rebuild = request(&[(10, 0, 0, &[8, 9])]);
+    let actual = runtime.step(&rebuild).unwrap();
+    let expected = fresh.step(&rebuild).unwrap();
+    assert_runtime_outputs_match(&runtime, &fresh, &actual, &expected, 2);
 }
 
 /// Independent scalar oracle: per-head Q/gate packing, partial rotation,

--- a/docs/EXECUTION_PLAN_AND_STATS.md
+++ b/docs/EXECUTION_PLAN_AND_STATS.md
@@ -1,0 +1,152 @@
+# Execution plans and phase statistics
+
+Ordinary decode, mixed prefill/decode and MTP now execute through
+`application::execution::ExecutionPlan::execute`. The plan records the phase,
+execution mode, live batch/token shape and workspace contract. It validates the
+phase/graph/workspace combination before calling the operation. The operation
+receives that validated plan; ABC and mixed graph dispatch use its graph slot/key.
+Existing `BatchPlan` remains responsible for tensor indexing, padding and model
+shape validation. Graph eligibility still comes from the runtime's graph policy.
+
+This is a shared execution boundary, not a replacement for each algorithm's
+orchestrator. Ordinary decode keeps its issue/finalize pipeline. MTP keeps its
+synchronous verification transaction and its existing state recovery behavior.
+No new MTP graphs or adaptive speculation policy are introduced here.
+
+## Ownership and completion
+
+| Workspace contract | Owner and lifetime |
+| --- | --- |
+| `Runtime` | Startup staging, hidden and sampling scratch; caller consumes results before reuse |
+| `Abc` | Runtime A/B/C buffers; issue enqueues work, matching finalize collects it; existing stream events order overlapping work |
+| `Proposer` | Startup token tape, hidden ping-pong and head scratch; tape is borrowed until target verification and catch-up finish |
+| `BorrowedTape` | Target borrows the proposer tape during verify/replay; no host re-upload |
+| `Recurrent` | Persistent recurrent snapshot; next verification transaction may overwrite it |
+
+Plans carry descriptions of existing borrows, not raw pointers or new allocations.
+Rust tensor ownership, shape checks and existing runtime in-flight checks still
+establish memory safety. A plan does not independently prove asynchronous lifetime
+correctness. Snapshot, restore, replay and readout may only enqueue GPU work;
+logical commit remains at the existing successful transaction boundary. Full
+attention keeps KV length/lease handling; GDN keeps snapshot/restore/replay.
+
+## Enable statistics
+
+Set these on the worker (or on the launcher so child processes inherit them):
+
+```bash
+export RUSTINFER_EXECUTION_STATS_EVERY=64
+export RUSTINFER_EXECUTION_GPU_SAMPLE_EVERY=16
+export RUST_LOG=info,execution_stats=info
+```
+
+`STATS_EVERY=0` or unset disables accounting entirely: no clock reads, metric
+locks, timer events or per-phase log records. Enabled counters use fixed storage
+allocated at startup. Cloning the metrics handle does not allocate. Logger sinks
+may allocate when a record is emitted.
+
+`GPU_SAMPLE_EVERY=0` or unset selects host timing only. With GPU sampling enabled,
+CUDA event pairs are allocated at startup, before graph priming and requests.
+The CPU backend returns no GPU timers. Sampling records on the compute stream
+and polls for completion on a later invocation of the same phase. If a sample is
+unfinished, the phase runs normally without overwriting its event pair or waiting.
+Host-only Wait/Commit phases never get CUDA timers. Timing failures disable that
+phase's GPU timer with a warning; the operation keeps its original error contract.
+
+Every N calls **per owner and phase**, `execution_stats` emits a cumulative
+`execution summary`. Every N successfully committed decode rounds it emits
+`execution tokens`. Normal owner destruction also logs the final host counters;
+forced process termination may leave only the last periodic summary. GPU samples
+can lag a phase invocation, and a final pending sample may be absent. Use N=1 for
+short diagnostic runs, not for a throughput comparison.
+
+For individual host spans use `RUST_LOG=info,execution_stats=debug`. Existing
+`MTP round` debug logs remain available under `infer_worker=debug`.
+
+```bash
+python3 scripts/summarize_execution_stats.py path/to/worker.log
+python3 scripts/summarize_execution_stats.py path/to/worker.log --json
+```
+
+Counters include warm-up and earlier requests in the same worker lifetime. To
+isolate a benchmark window, take differences of cumulative calls, host/GPU totals
+and token counters at its boundaries; maxima cannot be differenced.
+
+The tool keeps the latest cumulative summary per owner/phase in each file; it
+never sums repeated cumulative reports. Use one worker process lifetime per log
+file when comparing runs, especially for tensor-parallel workers.
+
+## Reading the numbers
+
+| Phase | Measured region |
+| --- | --- |
+| Prefill | Request-driven target eager/graph step, including sampling |
+| Decode | ABC forward/finalize/argmax submission or ordinary runtime step |
+| Mixed | Mixed ABC eager compute/merge region or graph replay; legacy fused eager step |
+| Draft | Entire proposer draft call, including metadata, existing wait and token download |
+| Verify | Target eager forward and greedy verification, excluding recurrent recovery |
+| Snapshot / Restore | Recurrent state copy submission |
+| Replay | Retained target prefix forward submission |
+| CatchUp | Proposer alignment and head forward, including its existing wait |
+| Readout | Target hidden normalization into caller-owned storage |
+| Wait | Explicit instrumented completion waits: ABC/mixed copy-out, target recovery/readout, proposer draft/catch-up |
+| Commit | Production ordinary ABC/MTP host state and output commit |
+
+`host_total_ms`, `host_mean_ms`, `host_max_ms` are wall-clock call durations.
+An asynchronous phase's host time measures submission; a synchronous phase also
+includes waits and CPU work. Wait spans can be nested inside Draft/CatchUp. Some
+implicit waits, notably token downloads inside greedy verification, remain within
+the enclosing phase. **Do not sum phase means or subtract Wait from GPU time.**
+Control uploads and scheduling outside these regions are not attributed to them.
+
+`gpu_samples`, `gpu_total_ms`, `gpu_mean_ms` are **sampled compute-stream elapsed
+spans**, not sums of kernel runtimes or whole-round latency. They can include
+stream waits and host dispatch gaps. Copy-in/out activity on other streams is not
+measured separately. A zero sample count means unavailable/not collected, not
+zero GPU cost. Compare the sample mean, not sampled total against full host total.
+
+`calls` includes failures; `failures` counts failed operations. Phase `tokens`
+counts successfully processed input rows, including speculative and replayed
+rows. `graph_calls` counts graph-mode executions (ordinary runtime cold paths may
+also warm/capture); it is not a committed-token count.
+
+Token summaries are emitted after successful production ABC/MTP commits and MTP
+reference-session rounds. `proposed`/`accepted` count speculative proposals and
+prefix matches; `emitted` counts committed output tokens; `materialized` counts
+retained input tokens. Bonus tokens are emitted but are not accepted drafts.
+Acceptance is weighted as total accepted / total proposed, and is absent when no
+drafts were proposed (ordinary decode or K=0). Cancellation can discard issued
+work, so processed rows can exceed emitted tokens. Mixed/stochastic serving
+commits do not yet contribute token summaries; their execution spans are covered.
+
+## Validation
+
+- CPU execution-plan tests reject verification on ordinary decode graphs and
+  invalid workspace use; counters preserve operation failures and disabled mode.
+- A mock asynchronous timer verifies unfinished event pairs are never overwritten.
+- Hybrid decoder tests exercise K=0..3 and rejection at every position with
+  statistics enabled, checking restore/replay counts and greedy continuation.
+- CUDA `scope_timing_supports_replay_and_keeps_stream_alive` tests event timing
+  around graph replay and persistent timer ownership.
+- Python parser tests cover cumulative snapshots, owner separation, ANSI logs and
+  absence of an acceptance rate for zero proposals.
+
+This change does not resolve the previously recorded long-text MTP/greedy output
+mismatch or stop-string behavior; these remain separate correctness work.
+
+### Local GPU smoke run (2026-09-10)
+
+RTX 4070 Ti SUPER, Qwen3.5-4B BF16; ordinary Graph and MTP K=1, 32-token
+requests, one measured repeat. Statistics reported every call, GPU sampled every
+8 eligible calls. Artifacts: `target/p1-execution-stats-smoke/`.
+
+Both paths completed. Short greedy comparisons matched 3/3. The benchmark still
+exited with its known stop-string failure in both modes; this is not a fully
+passing accuracy benchmark or a performance improvement claim.
+
+The MTP worker reported 166 verification rounds and 27 restore/replay operations,
+with no phase failures. Cumulative sampled compute-stream means were about
+19.57 ms verify, 0.34 ms snapshot, 0.32 ms restore and 15.29 ms replay. These
+include warm-up and diagnostic requests. They demonstrate that the new counters
+separate state-copy cost from retained-prefix recomputation; use a controlled
+measurement window for performance decisions.

--- a/docs/MTP_WORKSPACE_2026-09-10.md
+++ b/docs/MTP_WORKSPACE_2026-09-10.md
@@ -69,3 +69,26 @@ CUDA_ARCH=sm_89 cargo test -p infer-backend-cuda --test graph_memory scoped_copy
 旧 worker SHA256：`7f331ff21d0efb8305293bda548462db78fd166fb8bbe361f3823013345fd146`
 
 最终 worker SHA256：`9f50eff9a9f273d18a36f2f284d2590d84e9aed7682cd9295265186b221bfc81`
+
+
+## 后续小优化：复用设备 token 缓冲
+
+基于 `9099b5e`，proposer 将 pending token 与 draft ID 保留在连续的设备缓冲中。Target 验证直接读取该缓冲；拒绝后的单序列重放和 MTP catch-up 读取其保留前缀。省掉验证、重放（发生时）和 catch-up 的重复 token H2D。为拼成连续输入，新增一次 4-byte pending token D2D。
+
+本轮仍在 CPU 上验证接受前缀，draft ID 的 D2H 和现有事务同步仍保留；没有加入 CUDA Graph、GPU 接受判断、跨轮 issue/finalize 或 GDN 前缀状态保存。该内部接口只接收同一次 proposer 输出的 host/device 配对数据，仅用于单序列 MTP。普通、多序列和 prefill 继续走原有接口。
+
+验证：144 项 worker 单测 + 21 项 hybrid 测试通过；CPU Clippy `-D warnings`、格式检查和 CUDA release 构建通过。新增测试覆盖零 draft、不同接受前缀、EOS 截断、错误形状/多序列拒绝，并断言验证与重放不触碰 host token 上传缓冲、catch-up 元数据更新不覆盖设备 token。
+
+同卡新旧二进制各跑 graph / K=1 / K=3，3 个 prompt × 3 次 × 128 token，配置同上。总吞吐如下：
+
+| 模式 | 9099b5e tokens/s | 设备 token 复用 tokens/s | 变化 | 接受数/提议数（旧 → 新） |
+|---|---:|---:|---:|---|
+| graph | 57.90 | 57.69 | -0.37% | — |
+| mtp1 | 68.76 | 68.34 | -0.61% | 528/612 → 527/612 |
+| mtp3 | 63.43 | 63.68 | +0.40% | 717/1248 → 717/1248 |
+
+该轮结果不足以证明稳定的端到端吞吐提升。省掉的 ID 上传非常小，且仍有 CPU 接受判断、状态同步及模型计算；共享桌面 GPU 的波动也会影响结果。不把本次改动宣传为已实现完整 ABC 加速。
+
+新旧版短文本均 3/3 通过；与普通解码的长文本差异、stop-string 检查失败仍存在，基准仍以失败退出。
+
+原始记录：`target/mtp-bench-direct-before/results.json`、`target/mtp-bench-direct-after/results.json`，含配置、响应、日志和二进制 SHA256。

--- a/docs/MTP_WORKSPACE_2026-09-10.md
+++ b/docs/MTP_WORKSPACE_2026-09-10.md
@@ -1,0 +1,71 @@
+# MTP workspace 优化与实测（2026-09-10）
+
+本次改动补齐 MTP 热路径中遗漏的启动预分配，延续已有 ForwardScratch / GdnScratch 的所有权与容量约束。
+
+## 实现
+
+- `MtpWorkspace` 在 proposer 创建时分配控制索引、固定 block table、双缓冲 hidden、logits、argmax workspace 和 token ID 存储。每轮将所有 draft 索引和 pending token 一起上传；后续 token 直接从 GPU argmax 输出送入 embedding，整轮结束才下载 draft ID。没有逐 draft 的临时 logits/hidden/argmax 张量或索引上传。
+- Catch-up 对齐缓冲及两个 carry hidden 在启动时分配。carry 双缓冲保证未提交或失败的 chunk 不会改写已提交 hidden；CPU token/position Vec 保留容量。
+- target 使用调用方预分配的 normalized hidden；验证器使用 Runtime 已有 argmax 输出与 workspace。
+- GDN 快照在显式 MTP 启动时预留，计入 worker 启动内存预算。capture/restore 复用存储，在执行 stream 上依次排入 D2D 复制；去掉每个张量后的同步，保留事务提交所需同步。Qwen3.5-4B 每次快照仍须复制约 49.5 MiB，拒绝时仍须恢复并重放。
+- Serving 验证请求、retained request 及其 token/position/block table Vec 复用容量。必要的 block table 数据填充保留；Tensor 的 Arc 句柄克隆不复制设备内容。
+- 新增 `MathOps::copy_tensor`：CPU 默认同步复制，CUDA 使用指定 stream 的异步复制，校验形状、连续性、设备及部分重叠。源和目标的存储须存活至执行完成。
+
+MTP 仍以 eager 执行；本次没有新增 draft CUDA graph、动态 K 或改变拒绝策略。LM head 权重读取、必要的状态备份与拒绝后 replay 成本仍然存在。本次也没有把整个 Runtime 宣称为“零分配”。
+
+## GPU 对比
+
+RTX 4070 Ti SUPER 16 GiB，Qwen3.5-4B BF16；3 个长文本 prompt，各重复 3 次，每次 128 个输出 token。每个模式独立启动，包含预热。桌面仍使用该 GPU，测试显式允许最多 4096 MiB 背景显存和 60% 预检利用率；因此结果是该环境下的观测，不是隔离生产环境的保证。
+
+先跑预分配版本，再跑保留的旧二进制，最后跑完成 pending-token 合并上传的最终版本。下表使用旧版与最终版结果，总吞吐按总输出 token / 总请求耗时计算。
+
+| 模式 | 旧版 tokens/s | 最终版 tokens/s | 变化 | Draft 接受率（旧 → 新） |
+|---|---:|---:|---:|---|
+| graph | 61.41 | 61.61 | +0.33% | — |
+| mtp1 | 67.65 | 71.22 | +5.28% | 527/612 (86.11%) → 525/612 (85.78%) |
+| mtp3 | 62.23 | 67.00 | +7.66% | 717/1248 (57.45%) → 717/1248 (57.45%) |
+
+轮次耗时中位数（ms）；verify 包含必要的快照、恢复及 replay：
+
+| 模式 | Draft | Verify | Catch-up |
+|---|---:|---:|---:|
+| mtp1 | 2.832 → 2.571 | 20.667 → 19.778 | 0.992 → 0.706 |
+| mtp3 | 8.625 → 7.675 | 37.553 → 35.641 | 0.981 → 0.697 |
+
+## 正确性与验证边界
+
+- worker CPU 测试 141 + hybrid integration 21 项通过；覆盖分块 prefill、拒绝回滚、请求复用、索引 tile 边界、缓冲地址复用、未提交 carry 隔离和嵌套 Vec 复用。
+- CPU Clippy `-D warnings`、格式检查及 CUDA release 构建通过。
+- GPU 专项测试 `scoped_copy_is_capture_safe_and_rejects_partial_overlap` 通过：复制可被 graph capture，重放读取更新后的源，部分重叠返回错误。
+- 新旧版所有短文本均为 3/3；长文本与各自普通 graph 解码仍不全一致，stop-string 检查在普通模式及 MTP 都失败。这些是旧版已有的正确性缺口，本次没有宣称解决。基准会完整保存结果并以失败退出，不能把它视为全绿验收。
+- graph：最终版长文本与 graph 一致 9/9；与同模式旧版一致 8/9。
+- mtp1：最终版长文本与 graph 一致 6/9；与同模式旧版一致 7/9。
+- mtp3：最终版长文本与 graph 一致 3/9；与同模式旧版一致 9/9。
+
+普通 graph 跨运行也可能变化；因此不将所有输出差异归因于此次内存优化，也不据此证明与普通解码严格等价。
+
+## 复现与原始记录
+
+```bash
+CUDA_ARCH=sm_89 cargo build --release --locked -p infer-worker -p infer-scheduler -p infer-server
+python3 scripts/bench_qwen35_mtp.py --model /root/models/Qwen3.5-4B --gpu 0 \
+  --output target/mtp-bench-workspace-final --repeats 3 --tokens 128 \
+  --modes graph mtp1 mtp3 --max-background-memory-mib 4096 --max-background-utilization 60
+```
+
+输出目录必须不存在；若已存在，请换新目录。CPU 与 CUDA 专项验证命令：
+
+```bash
+cargo test -p infer-worker --no-default-features --lib --tests
+cargo clippy -p infer-worker --no-default-features --lib --tests -- -D warnings
+CUDA_ARCH=sm_89 cargo test -p infer-backend-cuda --test graph_memory scoped_copy_is_capture_safe_and_rejects_partial_overlap -- --ignored --test-threads=1
+```
+
+- 旧版结果：`target/mtp-bench-workspace-before/results.json`
+- 初版优化结果：`target/mtp-bench-workspace-after/results.json`
+- 最终结果：`target/mtp-bench-workspace-final/results.json`
+- 各目录保留配置、响应全文、worker 日志、GPU 信息及二进制 SHA256。
+
+旧 worker SHA256：`7f331ff21d0efb8305293bda548462db78fd166fb8bbe361f3823013345fd146`
+
+最终 worker SHA256：`9f50eff9a9f273d18a36f2f284d2590d84e9aed7682cd9295265186b221bfc81`

--- a/rustinfer.toml
+++ b/rustinfer.toml
@@ -66,6 +66,11 @@ log_level = "info"
 # deployment GPU after validating its memory headroom.
 capture_sizes = [1, 2, 4, 8, 16, 24, 32]
 
+# Optional Qwen3.5 text MTP (0 = disabled). Enabling requires
+# max_batch_seqs = 1, tensor_parallel_size = 1, and prefix caching disabled.
+# Requests must use greedy sampling. MTP currently runs eager.
+mtp_num_draft_tokens = 0
+
 # CUDA scratch memory (MiB). The graph arena is allocated lazily on first use;
 # the recycling-pool value is a retention ceiling, not an eager allocation.
 [cuda_memory]

--- a/scripts/bench_qwen35_mtp.py
+++ b/scripts/bench_qwen35_mtp.py
@@ -74,7 +74,8 @@ pool_retain_mib = 256
 
     def __enter__(self):
         info = gpu_info(self.args.gpu)
-        if info["memory_mib"] > 512 or info["utilization"] > 5:
+        if (info["memory_mib"] > self.args.max_background_memory_mib
+                or info["utilization"] > self.args.max_background_utilization):
             raise RuntimeError(f"GPU {self.args.gpu} is not idle: {info}")
         env = dict(os.environ, CUDA_VISIBLE_DEVICES=str(self.args.gpu))
         try:
@@ -168,6 +169,10 @@ def main():
     parser.add_argument("--modes", nargs="+", choices=["graph", "eager", "mtp1", "mtp2", "mtp3", "mtp4"], default=["graph", "eager", "mtp1", "mtp3"])
     parser.add_argument("--repeats", type=int, default=3)
     parser.add_argument("--tokens", type=int, default=128)
+    parser.add_argument("--max-background-memory-mib", type=int, default=512,
+                        help="Allowed pre-existing GPU memory usage (e.g. a display GPU)")
+    parser.add_argument("--max-background-utilization", type=int, default=5,
+                        help="Allowed pre-existing GPU utilization percentage")
     args = parser.parse_args()
     if args.repeats < 1 or args.tokens < 2 or len(set(args.modes)) != len(args.modes):
         parser.error("repeats must be positive, tokens >= 2, and modes unique")
@@ -199,7 +204,8 @@ def main():
                 assert [r["text"] for r in queued] == [r["text"] for r in accuracy[:2]]
                 # The second half of a speculative burst must not escape a stop string.
                 stopped = stack.request(checks[2], count=32, ignore_eos=False, stop=["return"])
-                assert "return" not in stopped["text"], stopped
+                # Preserve failures without losing the other modes' measurements.
+                stop_check = dict(passed="return" not in stopped["text"], response=stopped)
                 cancel_payload = dict(prompt=chat_prompt(prompts[0]), temperature=0, max_tokens=512,
                                       ignore_eos=True, stream=True)
                 cancel = urllib.request.Request(stack.url + "/v1/completions",
@@ -249,6 +255,7 @@ def main():
                     for key in ("draft_ms", "verify_ms", "catchup_ms"):
                         summary["round_median_" + key] = statistics.median(float(re.search(rf"\b{key}=([0-9.eE+-]+)", line)[1]) for line in rounds)
                 report["modes"][mode] = dict(accuracy=accuracy, measured=measured, summary=summary,
+                                             stop_check=stop_check,
                                              measured_graph_replays=graph_replays, measured_mtp_rounds=len(rounds))
                 if "graph" in report["modes"]:
                     baseline = report["modes"]["graph"]
@@ -262,8 +269,12 @@ def main():
             for result in report["modes"].values():
                 result["accuracy_matches_graph"] = [a["text"] == b["text"] for a, b in zip(result["accuracy"], baseline["accuracy"])]
                 result["performance_text_matches_graph"] = [a["text"] == b["text"] for a, b in zip(result["measured"], baseline["measured"])]
-            report["accuracy_passed"] = all(all(m["accuracy_matches_graph"]) for m in report["modes"].values())
-            assert report["accuracy_passed"], "short greedy responses differed; see results.json"
+            report["accuracy_passed"] = all(
+                all(m["accuracy_matches_graph"]) and all(m["performance_text_matches_graph"])
+                for m in report["modes"].values())
+            report["stop_checks_passed"] = all(m["stop_check"]["passed"] for m in report["modes"].values())
+            assert report["accuracy_passed"], "greedy responses differed; see results.json"
+            assert report["stop_checks_passed"], "stop string check failed; see results.json"
     except BaseException as error:
         report["error"] = repr(error)
         raise

--- a/scripts/bench_qwen35_mtp.py
+++ b/scripts/bench_qwen35_mtp.py
@@ -1,0 +1,275 @@
+"""Compare ordinary graph/eager serving with opt-in Qwen3.5 MTP over HTTP.
+
+Uses an isolated three-process stack per mode and warm, sequential requests.
+Reports wall-clock TTFT, TPOT, output tokens/s, exact response comparisons,
+and raw responses. Requires an idle GPU; never stops unrelated GPU processes.
+"""
+import argparse
+import concurrent.futures
+import json
+import os
+import re
+from pathlib import Path
+import signal
+import statistics
+import subprocess
+import time
+import urllib.error
+import urllib.request
+import uuid
+
+from e2e_qwen35_smoke import unused_port, file_sha256
+
+
+def gpu_info(index):
+    data = subprocess.check_output([
+        "nvidia-smi", f"--id={index}",
+        "--query-gpu=uuid,name,memory.used,utilization.gpu", "--format=csv,noheader,nounits"
+    ], text=True).strip().split(", ")
+    return dict(uuid=data[0], name=data[1], memory_mib=int(data[2]), utilization=int(data[3]))
+
+
+def chat_prompt(text):
+    return f"<|im_start|>user\n{text}<|im_end|>\n<|im_start|>assistant\n<think>\n\n</think>\n\n"
+
+
+class Stack:
+    def __init__(self, args, mode):
+        self.args, self.mode = args, mode
+        self.path = args.output / mode
+        self.path.mkdir()
+        self.processes = []
+        self.cluster = "mtp-bench-" + uuid.uuid4().hex
+        self.url = f"http://127.0.0.1:{unused_port()}"
+        self.opener = urllib.request.build_opener(urllib.request.ProxyHandler({}))
+        k = int(mode.removeprefix("mtp")) if mode.startswith("mtp") else 0
+        arena = 0 if mode == "eager" else 256
+        self.config = self.path / "config.toml"
+        self.config.write_text(f'''model = {json.dumps(str(args.model))}
+model_name = "Qwen3.5-4B"
+cluster_id = "{self.cluster}"
+device = "cuda:0"
+host = "127.0.0.1"
+port = {self.url.rsplit(':', 1)[1]}
+request_timeout_secs = 180
+max_batch_tokens = 128
+max_batch_seqs = 1
+max_model_len = 2048
+max_inflight_requests = 8
+batch_wait_ms = 0
+paged_block_size = 1
+chunked_prefill_size = 32
+enable_prefix_caching = false
+num_blocks = 2048
+ignore_eos = false
+worker_heartbeat_timeout_secs = 30
+log_level = "debug"
+capture_sizes = {"[]" if mode == "eager" else "[1]"}
+mtp_num_draft_tokens = {k}
+[cuda_memory]
+kernel_workspace_mib = 256
+graph_arena_mib = {arena}
+pool_retain_mib = 256
+''')
+
+    def __enter__(self):
+        info = gpu_info(self.args.gpu)
+        if info["memory_mib"] > 512 or info["utilization"] > 5:
+            raise RuntimeError(f"GPU {self.args.gpu} is not idle: {info}")
+        env = dict(os.environ, CUDA_VISIBLE_DEVICES=str(self.args.gpu))
+        try:
+            for name in ("scheduler", "server", "worker"):
+                with (self.path / f"{name}.log").open("w") as log:
+                    self.processes.append(subprocess.Popen([
+                        str(self.args.bin_dir / f"rustinfer-{name}"), "--config", str(self.config)
+                    ], stdout=log, stderr=subprocess.STDOUT, env=env))
+            deadline = time.monotonic() + 300
+            while time.monotonic() < deadline:
+                if any(p.poll() is not None for p in self.processes):
+                    raise RuntimeError(f"{self.mode} startup failed; see {self.path}")
+                try:
+                    with self.opener.open(self.url + "/ready", timeout=2) as r:
+                        if r.status == 200:
+                            (self.path / "gpu_ready.json").write_text(json.dumps(gpu_info(self.args.gpu)))
+                            return self
+                except (urllib.error.URLError, TimeoutError):
+                    pass
+                time.sleep(0.2)
+            raise TimeoutError(f"{self.mode} readiness timed out")
+        except BaseException:
+            self.__exit__(None, None, None)
+            raise
+
+    def __exit__(self, *_):
+        for p in reversed(self.processes):
+            if p.poll() is None:
+                p.terminate()
+        for p in reversed(self.processes):
+            try:
+                p.wait(timeout=10)
+            except subprocess.TimeoutExpired:
+                p.kill()
+                p.wait(timeout=10)
+        for path in Path("/tmp").glob(f"rustinfer-{self.cluster}-*.ipc"):
+            path.unlink(missing_ok=True)
+
+    def request(self, prompt, count=128, stream=True, ignore_eos=True, **extra):
+        payload = dict(model="Qwen3.5-4B", prompt=chat_prompt(prompt), temperature=0,
+                       max_tokens=count, ignore_eos=ignore_eos, stream=stream,
+                       stream_options={"include_usage": True}, **extra)
+        req = urllib.request.Request(self.url + "/v1/completions", json.dumps(payload).encode(),
+                                     {"Content-Type": "application/json"})
+        started = time.perf_counter()
+        first = None
+        content, chunks, usage = "", [], None
+        with self.opener.open(req, timeout=180) as response:
+            if not stream:
+                raw = json.load(response)
+                return dict(text=raw["choices"][0]["text"], usage=raw["usage"], response=raw)
+            done = False
+            for line in response:
+                line = line.decode().strip()
+                if line.startswith("event: error"):
+                    raise RuntimeError(line)
+                if not line.startswith("data: "):
+                    continue
+                if line == "data: [DONE]":
+                    done = True
+                    break
+                raw = json.loads(line[6:])
+                chunks.append(raw)
+                if raw.get("error"):
+                    raise RuntimeError(raw)
+                usage = raw.get("usage") or usage
+                for choice in raw.get("choices", []):
+                    delta = choice.get("text", "")
+                    if delta:
+                        first = first or time.perf_counter()
+                        content += delta
+                    if choice.get("finish_reason") == "error":
+                        raise RuntimeError(raw)
+        ended = time.perf_counter()
+        assert done and first is not None and usage, chunks
+        tokens = usage["completion_tokens"]
+        if ignore_eos:
+            assert tokens == count, (tokens, count, content)
+        return dict(text=content, usage=usage, ttft_ms=(first-started)*1000,
+                    elapsed_ms=(ended-started)*1000,
+                    tpot_ms=(ended-first)*1000/max(tokens-1, 1),
+                    output_tokens_per_second=tokens/(ended-started), chunks=chunks)
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--model", type=Path, required=True)
+    parser.add_argument("--output", type=Path, required=True)
+    parser.add_argument("--gpu", type=int, default=7)
+    parser.add_argument("--bin-dir", type=Path, default=Path(__file__).resolve().parents[1]/"target/release")
+    parser.add_argument("--modes", nargs="+", choices=["graph", "eager", "mtp1", "mtp2", "mtp3", "mtp4"], default=["graph", "eager", "mtp1", "mtp3"])
+    parser.add_argument("--repeats", type=int, default=3)
+    parser.add_argument("--tokens", type=int, default=128)
+    args = parser.parse_args()
+    if args.repeats < 1 or args.tokens < 2 or len(set(args.modes)) != len(args.modes):
+        parser.error("repeats must be positive, tokens >= 2, and modes unique")
+    args.model, args.output, args.bin_dir = args.model.resolve(), args.output.resolve(), args.bin_dir.resolve()
+    args.output.mkdir(parents=True, exist_ok=False)
+    signal.signal(signal.SIGTERM, lambda *_: (_ for _ in ()).throw(InterruptedError("terminated")))
+    prompts = [
+        "Explain how a hash table works, including collisions and resizing. Give a detailed answer.",
+        "请详细解释 Rust 的所有权、借用与生命周期，并给出例子。",
+        "Write Python code implementing merge sort with comments and example tests.",
+    ]
+    checks = ["What is 2 + 2? Answer with just the number.",
+              "用一句话介绍 Rust 编程语言。",
+              "Write a Python function that adds two numbers. Output only code."]
+    report = {"modes": {}, "gpu_before": gpu_info(args.gpu), "configuration": vars(args).copy(),
+              "binary_sha256": {n: file_sha256(args.bin_dir/f"rustinfer-{n}") for n in ("worker", "server", "scheduler")}}
+    def save():
+        (args.output/"results.json").write_text(json.dumps(report, ensure_ascii=False, indent=2, default=str))
+    try:
+        for mode in args.modes:
+            print(f"Starting {mode}", flush=True)
+            with Stack(args, mode) as stack:
+                accuracy = [stack.request(p, count=32, stream=False, ignore_eos=False) for p in checks]
+                streamed = stack.request(checks[1], count=32, ignore_eos=False)
+                assert streamed["text"] == accuracy[1]["text"], (mode, "SSE mismatch")
+                # Two HTTP requests exercise queuing at worker max_batch_seqs=1.
+                with concurrent.futures.ThreadPoolExecutor(2) as pool:
+                    queued = list(pool.map(lambda p: stack.request(p, count=32, stream=False, ignore_eos=False), checks[:2]))
+                assert [r["text"] for r in queued] == [r["text"] for r in accuracy[:2]]
+                # The second half of a speculative burst must not escape a stop string.
+                stopped = stack.request(checks[2], count=32, ignore_eos=False, stop=["return"])
+                assert "return" not in stopped["text"], stopped
+                cancel_payload = dict(prompt=chat_prompt(prompts[0]), temperature=0, max_tokens=512,
+                                      ignore_eos=True, stream=True)
+                cancel = urllib.request.Request(stack.url + "/v1/completions",
+                    json.dumps(cancel_payload).encode(), {"Content-Type": "application/json"})
+                with stack.opener.open(cancel, timeout=180) as response:
+                    for line in response:
+                        if line.startswith(b"data: ") and b'"text":"' in line.replace(b" ", b""):
+                            break
+                after_cancel = stack.request(checks[0], count=32, stream=False, ignore_eos=False)
+                assert after_cancel["text"] == accuracy[0]["text"]
+                if mode.startswith("mtp"):
+                    invalid = urllib.request.Request(stack.url + "/v1/completions",
+                        json.dumps(dict(prompt="hello", temperature=1, max_tokens=1)).encode(),
+                        {"Content-Type": "application/json"})
+                    try:
+                        stack.opener.open(invalid, timeout=5)
+                    except urllib.error.HTTPError as error:
+                        assert error.code == 400, error.code
+                    else:
+                        raise AssertionError("MTP accepted stochastic sampling")
+                for p in prompts:
+                    stack.request(p, count=args.tokens)  # discard warm-up
+                log_start = (stack.path / "worker.log").stat().st_size
+                measured = []
+                for repeat in range(args.repeats):
+                    for i, p in enumerate(prompts):
+                        result = stack.request(p, count=args.tokens)
+                        result.update(prompt_index=i, repeat=repeat)
+                        measured.append(result)
+                summary = {key: statistics.median(r[key] for r in measured)
+                           for key in ("ttft_ms", "tpot_ms", "elapsed_ms", "output_tokens_per_second")}
+                summary["aggregate_output_tokens_per_second"] = sum(r["usage"]["completion_tokens"] for r in measured) / (sum(r["elapsed_ms"] for r in measured)/1000)
+                with (stack.path / "worker.log").open("rb") as log:
+                    log.seek(log_start)
+                    measured_log = re.sub(r"\x1b\[[0-9;]*m", "", log.read().decode())
+                (stack.path / "measured-worker.log").write_text(measured_log)
+                graph_replays = measured_log.count("replaying decode CUDA graph")
+                rounds = [line for line in measured_log.splitlines() if "MTP round" in line]
+                if mode == "graph":
+                    assert graph_replays > 0, "ordinary graph baseline did not replay graphs"
+                elif mode == "eager":
+                    assert graph_replays == 0, "eager baseline replayed graphs"
+                else:
+                    assert rounds and graph_replays == 0, "MTP serving path was not exercised"
+                    for key in ("proposed", "accepted", "emitted"):
+                        summary[key] = sum(int(re.search(rf"\b{key}=(\d+)", line)[1]) for line in rounds)
+                    for key in ("draft_ms", "verify_ms", "catchup_ms"):
+                        summary["round_median_" + key] = statistics.median(float(re.search(rf"\b{key}=([0-9.eE+-]+)", line)[1]) for line in rounds)
+                report["modes"][mode] = dict(accuracy=accuracy, measured=measured, summary=summary,
+                                             measured_graph_replays=graph_replays, measured_mtp_rounds=len(rounds))
+                if "graph" in report["modes"]:
+                    baseline = report["modes"]["graph"]
+                    report["modes"][mode]["accuracy_matches_graph"] = [a["text"] == b["text"] for a, b in zip(accuracy, baseline["accuracy"])]
+                    report["modes"][mode]["performance_text_matches_graph"] = [a["text"] == b["text"] for a, b in zip(measured, baseline["measured"])]
+                print(mode, json.dumps(summary), flush=True)
+                save()
+            time.sleep(1)
+        if "graph" in report["modes"]:
+            baseline = report["modes"]["graph"]
+            for result in report["modes"].values():
+                result["accuracy_matches_graph"] = [a["text"] == b["text"] for a, b in zip(result["accuracy"], baseline["accuracy"])]
+                result["performance_text_matches_graph"] = [a["text"] == b["text"] for a, b in zip(result["measured"], baseline["measured"])]
+            report["accuracy_passed"] = all(all(m["accuracy_matches_graph"]) for m in report["modes"].values())
+            assert report["accuracy_passed"], "short greedy responses differed; see results.json"
+    except BaseException as error:
+        report["error"] = repr(error)
+        raise
+    finally:
+        save()
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/qwen35_mtp_precision.py
+++ b/scripts/qwen35_mtp_precision.py
@@ -1,0 +1,116 @@
+"""Qwen3.5 MTP numerical reference using official Transformers layer operations.
+
+Transformers does not load MTP natively. This explicitly builds the head from
+checkpoint tensors following vLLM's qwen3_5_mtp.py: dual norm, [embedding, hidden]
+concat, fc, one full-attention decoder, final norm, shared LM head.
+
+Export, run worker test qwen35_mtp_checkpoint with QWEN35_MTP_REFERENCE and
+QWEN35_MTP_DUMP_DIR, then --compare. Files are flattened little-endian FP32.
+"""
+import argparse
+import copy
+import json
+from pathlib import Path
+import numpy as np
+
+
+def compare(args):
+    meta = json.loads((args.output / "metadata.json").read_text())
+    report = []
+    for name in ["target", "isolated_hidden", "isolated_logits", "integrated_hidden", "integrated_logits", "chunked_hidden", "chunked_logits"]:
+        source = "target" if name == "target" else "mtp_" + name.rsplit("_", 1)[1]
+        ref = np.fromfile(args.output / (source + ".f32"), dtype="<f4").astype(np.float64)
+        got = np.fromfile(args.compare / (name + ".f32"), dtype="<f4").astype(np.float64)
+        assert ref.shape == got.shape and ref.size and np.isfinite(ref).all() and np.isfinite(got).all(), name
+        error = float(np.linalg.norm(ref-got) / max(np.linalg.norm(ref), 1e-30))
+        row = dict(tensor=name, relative_l2=error, max_abs=float(np.max(np.abs(ref-got))))
+        limit = 0.03 if name.startswith(("isolated", "chunked")) else 0.08
+        assert error < limit, row
+        if name.endswith("logits"):
+            r = ref.reshape(-1, meta["vocab_size"])
+            g = got.reshape(r.shape)
+            agree = r.argmax(-1) == g.argmax(-1)
+            row.update(top1_matches=int(agree.sum()), rows=len(agree), last_top1_match=bool(agree[-1]))
+            # BF16 can reverse near ties; large-margin decisions must agree.
+            top = np.partition(r, -2, axis=1)[:, -2:]
+            confident = top[:,1] - top[:,0] > 0.5
+            assert agree[confident].all() and agree[-1], row
+        report.append(row)
+        print(json.dumps(row))
+    # Chunk equivalence uses the identical conditioning hidden, isolating cache alignment.
+    for suffix in ["hidden", "logits"]:
+        full = np.fromfile(args.compare / f"isolated_{suffix}.f32", dtype="<f4").astype(np.float64)
+        chunk = np.fromfile(args.compare / f"chunked_{suffix}.f32", dtype="<f4").astype(np.float64)
+        error = float(np.linalg.norm(full-chunk) / max(np.linalg.norm(full), 1e-30))
+        assert error < 0.02, (suffix,error)
+        report.append(dict(tensor="whole_vs_chunked_"+suffix, relative_l2=error))
+    (args.compare / "comparison.json").write_text(json.dumps(report,indent=2))
+
+
+def export(args):
+    import torch
+    import transformers
+    from safetensors import safe_open
+    from transformers import AutoTokenizer, Qwen3_5ForConditionalGeneration
+    from transformers.models.qwen3_5.modeling_qwen3_5 import Qwen3_5DecoderLayer, Qwen3_5RMSNorm, Qwen3_5TextRotaryEmbedding
+    torch.set_num_threads(8)
+    tokenizer = AutoTokenizer.from_pretrained(args.model)
+    model = Qwen3_5ForConditionalGeneration.from_pretrained(args.model, dtype=torch.bfloat16, attn_implementation="eager").to(args.device).eval()
+    text = model.model.language_model
+    cfg = copy.deepcopy(model.config.text_config)
+    cfg.layer_types = ["full_attention"]
+    cfg.num_hidden_layers = 1
+    cfg._attn_implementation = "eager"
+    weights = {}
+    for file in Path(args.model).glob("*.safetensors"):
+        with safe_open(file, framework="pt", device="cpu") as f:
+            for name in f.keys():
+                if name.startswith("mtp."):
+                    weights[name[4:]] = f.get_tensor(name)
+    assert len(weights) == 15, sorted(weights)
+    def norm(name):
+        layer = Qwen3_5RMSNorm(cfg.hidden_size, cfg.rms_norm_eps)
+        layer.load_state_dict({"weight": weights[name+".weight"]})
+        return layer.to(device=args.device, dtype=torch.bfloat16).eval()
+    en, hn, final = norm("pre_fc_norm_embedding"), norm("pre_fc_norm_hidden"), norm("norm")
+    fc = torch.nn.Linear(2*cfg.hidden_size, cfg.hidden_size, bias=False)
+    fc.load_state_dict({"weight":weights["fc.weight"]})
+    fc = fc.to(device=args.device,dtype=torch.bfloat16).eval()
+    block = Qwen3_5DecoderLayer(cfg,0)
+    block.load_state_dict({k[len("layers.0."):]:v for k,v in weights.items() if k.startswith("layers.0.")})
+    block = block.to(device=args.device,dtype=torch.bfloat16).eval()
+    rope = Qwen3_5TextRotaryEmbedding(cfg,device=args.device)
+    ids = tokenizer.encode(args.prompt,add_special_tokens=False)
+    args.output.mkdir(parents=True,exist_ok=True)
+    def dump(name,t):
+        t.detach().float().cpu().numpy().astype("<f4").tofile(args.output / (name+".f32"))
+    with torch.inference_mode():
+        tokens = torch.tensor([ids],device=args.device)
+        target = text(input_ids=tokens,use_cache=False).last_hidden_state
+        dump("target",target)
+        n = len(ids)-1
+        x = fc(torch.cat([en(text.embed_tokens(tokens[:,1:])), hn(target[:,:-1])],dim=-1))
+        positions = torch.arange(n,device=args.device)[None,:]
+        mask = torch.full((n,n), torch.finfo(x.dtype).min, device=args.device,dtype=x.dtype).triu(1)[None,None]
+        out = final(block(x,position_embeddings=rope(x,positions),attention_mask=mask))
+        logits = model.lm_head(out)
+        dump("mtp_hidden",out)
+        dump("mtp_logits",logits)
+    (args.output / "tokens.json").write_text(json.dumps(ids))
+    meta = dict(model=args.model, prompt=args.prompt,tokens=len(ids),hidden_size=cfg.hidden_size,vocab_size=cfg.vocab_size,
+                torch=torch.__version__,transformers=transformers.__version__,dtype="bfloat16",
+                reference="Transformers Qwen3.5 layer operations + vLLM MTP head composition",
+                sources=["https://github.com/vllm-project/vllm/blob/main/vllm/model_executor/models/qwen3_5_mtp.py",
+                         "https://github.com/huggingface/transformers/blob/main/src/transformers/models/qwen3_5/modeling_qwen3_5.py"])
+    (args.output / "metadata.json").write_text(json.dumps(meta,indent=2))
+    print(json.dumps(meta))
+
+if __name__ == "__main__":
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("--model", default="/mnt/md2/liuwenqi/vllm_bench/Qwen3.5-4B")
+    p.add_argument("--device", default="cuda:0")
+    p.add_argument("--output", type=Path,required=True)
+    p.add_argument("--compare", type=Path)
+    p.add_argument("--prompt", default="The capital of France is Paris. 2 + 2 = 4. 请用中文解释 Rust 的所有权：每个值都有一个所有者。 Python example: def add(a, b): return a + b. The next prime after 7 is")
+    args = p.parse_args()
+    compare(args) if args.compare else export(args)

--- a/scripts/summarize_execution_stats.py
+++ b/scripts/summarize_execution_stats.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python3
+"""Read cumulative execution summaries; keep the latest per owner/phase.
+
+Usage: python3 scripts/summarize_execution_stats.py path/to/worker.log [--json]
+Host spans can nest (Wait within Draft/CatchUp); never sum them as latency.
+GPU times are sampled compute-stream spans, not a sum of kernel durations.
+"""
+import argparse
+import json
+import re
+from pathlib import Path
+
+ANSI = re.compile(r"\x1b\[[0-9;]*m")
+FIELD = re.compile(r'\b(\w+)=(?:"([^"\n]*)"|([^\s,]+))')
+
+
+def parse_log(text):
+    owners = {}
+    for line in ANSI.sub("", text).splitlines():
+        if "execution_stats" not in line:
+            continue
+        if "execution summary" not in line and "execution tokens" not in line:
+            continue
+        fields = {}
+        for key, quoted, bare in FIELD.findall(line):
+            value = quoted or bare
+            try:
+                value = json.loads(value)
+            except (ValueError, TypeError):
+                pass
+            fields[key] = value
+        owner = fields.pop("owner", None)
+        if owner is None:
+            continue
+        record = owners.setdefault(owner, {"phases": {}})
+        if "execution summary" in line:
+            phase = fields.pop("phase", None)
+            if phase is not None:
+                record["phases"][phase] = fields
+        else:
+            record["tokens"] = fields
+    return owners
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("logs", nargs="+", type=Path)
+    parser.add_argument("--json", action="store_true")
+    args = parser.parse_args()
+    reports = {str(path): parse_log(path.read_text()) for path in args.logs}
+    if args.json:
+        print(json.dumps(reports, indent=2, ensure_ascii=False))
+        return
+    for path, owners in reports.items():
+        print(path)
+        if not owners:
+            print("  No summaries. Enable RUSTINFER_EXECUTION_STATS_EVERY and execution_stats=info.")
+        for owner, report in owners.items():
+            print(f"  {owner}: phase / calls / host mean ms / GPU mean ms / GPU samples / failures")
+            for phase, s in report["phases"].items():
+                gpu_mean = s.get("gpu_mean_ms")
+                gpu_text = f"{gpu_mean:.3f}" if isinstance(gpu_mean, (float, int)) else "n/a"
+                print(f"    {phase:10} {s.get('calls', 0):6}  "
+                      f"{s.get('host_mean_ms', 0):9.3f}  "
+                      f"{gpu_text:>12}  "
+                      f"{s.get('gpu_samples', 0):6}  {s.get('failures', 0)}")
+            if "tokens" in report:
+                print("    tokens: " + json.dumps(report["tokens"], ensure_ascii=False))
+    print("Host spans may nest; GPU spans are sampled. Do not sum phase means as request latency.")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/tests/test_execution_stats.py
+++ b/scripts/tests/test_execution_stats.py
@@ -1,0 +1,34 @@
+import importlib.util
+import unittest
+from pathlib import Path
+
+spec = importlib.util.spec_from_file_location(
+    "execution_stats", Path(__file__).resolve().parents[1] / "summarize_execution_stats.py")
+module = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(module)
+
+
+class ExecutionStatsTests(unittest.TestCase):
+    def test_cumulative_summaries_are_not_double_counted(self):
+        parsed = module.parse_log('''
+INFO execution_stats: execution summary owner="target" phase=Verify calls=10 host_mean_ms=2.5
+INFO execution_stats: execution summary owner="target" phase=Verify calls=20 host_mean_ms=3.5
+INFO execution_stats: execution summary owner="proposer" phase=Draft calls=20 gpu_mean_ms=0.25
+INFO execution_stats: execution tokens owner="target" rounds=20 proposed=0 accepted=0 emitted=20
+''')
+        self.assertEqual(parsed["target"]["phases"]["Verify"]["calls"], 20)
+        self.assertEqual(parsed["proposer"]["phases"]["Draft"]["gpu_mean_ms"], 0.25)
+        self.assertNotIn("acceptance_rate", parsed["target"]["tokens"])
+
+    def test_ansi_and_unrelated_lines(self):
+        parsed = module.parse_log(
+            '\x1b[32mINFO\x1b[0m execution_stats: execution summary owner="target" '
+            'phase=Decode calls=1 failures=0\n'
+            'DEBUG execution_stats: execution phase owner="target" phase=Decode tokens=1\n'
+            'INFO other: execution summary owner="bad" phase=Verify calls=99\n')
+        self.assertEqual(set(parsed), {"target"})
+        self.assertEqual(parsed["target"]["phases"]["Decode"]["calls"], 1)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
为 Qwen3.5 dense 接入可选 MTP 投机解码，并统一普通 decode、mixed 和 MTP 的执行阶段接口与统计。设置 `mtp_num_draft_tokens > 0` 后，MTP head 生成草稿，主模型验证并批量提交 token；默认值为 0。

## 实现

- 独立 proposer、verifier、session 和静态分发 serving execution，复用主模型 embedding/readout。目标模型验证 K+1 行；拒绝后回收 KV 尾部，通过 GDN 快照恢复和保留前缀重放恢复递归状态。
- 接入分块 prefill、多 token 提交、取消与结束处理。区分 `accepted_drafts` 和 `materialized_tokens`；移除旧 `Sampler::probs`、`Sampler::verify` 和 `AcceptReject`，后端新增 `concat_cols`。
- 启动时预分配 MTP 控制数据、设备 token tape、hidden 双缓冲和 recurrent snapshot。批量传输控制数据，target verify/replay 与 proposer catch-up 直接借用设备 token tape，减少重复 H2D 和热路径临时分配。
- `ExecutionPlan` 统一阶段、eager/Graph 模式、batch/token 形状和 workspace 使用约定，并校验组合。普通 ABC 保留 issue/finalize 流水线；MTP 保留 draft → verify → restore/replay → catch-up → commit 调度。此次统一没有新增 MTP CUDA Graph。
- 新增各阶段调用数、失败数、处理 token 数、host 时间，以及可选的 CUDA event GPU 采样；提交后单独统计 proposed/accepted/emitted。统计默认关闭，GPU event 在启动时预分配，未完成采样只轮询、不增加同步等待。提供日志汇总脚本和使用文档。
- 修复格式、依赖和前端关闭竞态相关 CI 问题；CI 增加统计解析脚本测试。

## 使用与范围

当前 MTP 限文本、greedy、TP=1、单活跃请求，必须关闭 prefix caching；MTP 使用 eager。随机采样、多模态 MTP 和 MTP CUDA Graph 暂未支持。

统计开关：`RUSTINFER_EXECUTION_STATS_EVERY`；GPU 采样开关：`RUSTINFER_EXECUTION_GPU_SAMPLE_EVERY`。完整口径、workspace 生命周期和覆盖范围见 [执行计划与统计说明](docs/EXECUTION_PLAN_AND_STATS.md)。计划元数据本身不证明异步内存生命周期；实际安全性仍依赖 Tensor 所有权及已有 stream/event 约束。

## 验证与性能

- 最新执行计划提交 `0c68de5`：169 项 worker 单元/集成测试通过，core/CPU 测试与 doctest 共 43 项通过，Python 解析测试 2 项通过；相关 core/CPU/worker Clippy、格式检查通过。
- CUDA worker/scheduler/server Release 构建通过；GPU event 在 graph replay 中的计时及 stream 生命周期测试通过。
- RTX 4070 Ti SUPER、Qwen3.5-4B GPU smoke 完成普通 Graph 与 MTP K=1 两条路径，短文本对照各 3/3 一致。但 stop-string 检查仍失败，长文本 MTP/greedy 一致性也存在已记录问题，不能视为完整正确性通过。
- 先前 workspace 对照中，K=1 吞吐约 67.65 → 71.22 tokens/s，K=3 约 62.23 → 67.00 tokens/s；设备 token tape 的后续对照未显示明确额外收益。这些是单机测量，不保证其他环境收益，详细记录见 [MTP workspace 测量](docs/MTP_WORKSPACE_2026-09-10.md)。
- 本次执行接口统一和指标建设没有已证实的吞吐提升。GPU 采样日志包含 warm-up，阶段可能嵌套，不能把阶段均值相加当作端到端耗时。以上验证为本地结果，不代表最新远端 CI 状态。

权重读取与 H2D 双缓冲流水线尚未实现，不属于本 PR 当前改动。
